### PR TITLE
[최주영] sprint3

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -22,14 +22,14 @@ button {
 }
 
 .header__content, .visual__content, .features, .banner__content, .footer__content {
-    width: 1120px;
+    max-width: 1120px;
     margin: 0 auto;
 }
+
 
 header {
     position: sticky;
     top: 0;
-    max-width: 100%;
     background-color: #fff;
     border-bottom: 1px solid #dfdfdf;
     z-index: 2;
@@ -145,7 +145,6 @@ header button {
 }
 
 footer {
-    width: 100%;
     height: 160px;
     background-color: var(--gray-900);
     font-size: 1rem;
@@ -191,20 +190,172 @@ footer {
 }
 
 
-/* 스프린트 미션 3에서 반응형 작업 예정 */
-
-@media (max-width: 1199px) {
-    html {
-        font-size: 14px;
+@media (max-width: 1200px) {
+    .header__content, .visual__content, .features, .banner__content, .footer__content {
+        max-width: 100%;
+        margin: 0 24px;
     }
 
-    .header__content, .visual__content, .features, .banner__content, .footer__content {
-        width: 90%;
+    .visual img, .banner img {
+        max-width: 1000px;
+        width: 100vw;
+        height: auto;
+    }
+
+    .visual h1 br, .features h1 br {
+        display: none;    
+    }
+
+    .visual h1, .features__content *{
+        margin: 0;
+    }
+
+    .visual {
+        height: 770px;
+    }
+
+    .visual__content, .banner__content {
+        flex-direction: column;
+        align-items: center;
+        justify-content: space-between;
+    }
+
+    .visual__information {
+        display: flex;
+        flex-direction: column;
+        text-align: center;
+        gap: 1.5rem;
+        top: 80px;
+        bottom: 0;
+    }
+
+    .features {
+        margin-top: 1.5rem;
+    }
+
+    .features__content {
+        flex-direction: column;
+        margin: 0 0 3.25rem;
+        align-items: flex-start;
+        gap: 0;
+    }
+
+    .features__content:not(:nth-child(odd)) {
+        flex-direction: column-reverse;
+        text-align: right;
+        align-items: flex-end;
+    }    
+
+    .features h1 {
+        font-size: 2rem;
+        margin: 1rem 0 1.5rem;
+    }
+
+    .features__subtitle {
+        margin-top: 1.5rem;
+    }
+
+    .features__subtitle, .features__description {
+        font-size: 1.125rem;
+        line-height: 1.625rem;
+    }
+
+    .features img {
+        width: 100%;
+        height: auto;
+    }
+
+    .banner {
+        height: 920px;
+        margin-top: 0;
+    }
+
+    .banner h1 {
+        top: 200px;
+        bottom: 0;
+        text-align: center;
+    }
+
+    .footer__content {
+        margin: 0 100px;
     }
 }
 
-@media (max-width: 767px) {
-    html {
-        font-size: 12px;
+@media (max-width: 768px) {
+    
+    h1 {
+        font-size: 2rem;
+    }
+    
+    .header__content, .visual__content, .features, .banner__content, .footer__content {
+        margin: 0 16px;
+    }
+
+    header img {
+        width: 105px;
+        object-fit: cover;
+        object-position: right;
+    }
+
+    .visual img, .banner img {
+        max-width: 560px;
+    }
+
+    .visual, .banner {
+        height: 540px;
+    }
+
+    .visual h1 br {
+        display: block;    
+    }
+
+    .visual button {
+        width: 15rem;
+        font-size: 1.125rem;
+    }
+
+    .features {
+        margin-top: 3.25rem;
+        margin-bottom: 5.1rem;
+    }
+
+    .features__content {
+        margin: 0 0 2.5rem;
+    }
+
+    .features h1 {
+        font-size: 1.5rem;
+        margin: 0.5rem 0 1rem;
+    }
+
+    .features__subtitle, .features__description {
+        font-size: 1rem;
+        line-height: 1.5rem;
+    }
+
+    .banner h1 {
+        top: 120px;
+    }
+
+    .footer__content {
+        margin: 0 32px;
+        display: grid;
+        grid-template-areas: 
+        "menu sns"
+        "company .";
+    }
+
+    .footer__company {
+        grid-area: company;
+        position: relative;
+        top: 60px;
+    }
+
+    .footer__menu {
+        grid-area: menu;
+    }
+
+    .footer__sns {
+        grid-area: sns;
     }
 }

--- a/css/login.css
+++ b/css/login.css
@@ -50,17 +50,24 @@ input:focus {
     outline-color: var(--blue);
 }
 
-.password {
-    background-image: url("signup_images/btn_visibility_on.png");
-/*  background-image: url("signup_images/btn_visibility_off.png"); */
-/*  자바스크립트 학습 후 작업 예정 */
-    background-size: 1.5rem;
-    background-repeat: no-repeat;
-    background-position: right;
-    background-origin: content-box;
+input::-ms-reveal, input::-ms-clear {
+    display: none;
 }
 
-input::-ms-reveal, input::-ms-clear {
+.password {
+    position: relative;
+}
+
+.password__visibility {
+    width: 1.5rem;
+    height: 1.5rem;
+    position: absolute;
+    right: 1.5rem;
+    bottom: 0.95rem;
+    cursor: pointer;
+}
+
+.password__visibility--off {
     display: none;
 }
 
@@ -77,13 +84,13 @@ button {
     font-size: 1.25rem;
     font-weight: 600;
     color: #fff;
+    cursor: pointer;
 }
 
 .button--disabled {
     display: none;
     background-color: var(--gray-400);
 }
-/* 자바스크립트 학습 후 작업 예정 */
 
 .button--enabled {
     background-color: var(--blue);
@@ -127,14 +134,10 @@ button {
     color: var(--blue);
 }
 
-@media all and (max-width: 1024px) {
-    body {
-        width: 80%;
-    } 
-  }
-
 @media all and (max-width: 767px) {
     html{
+        min-width: 400px;
         font-size: 14px;
+        margin: 0 16px;
     }
   }

--- a/index.html
+++ b/index.html
@@ -5,13 +5,32 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <link rel="stylesheet" href="style.css">
-    <link rel="icon" href="images/favicon.ico">
+
+    <meta property="og:image" content="images/index/logo.png">
+    <meta property="og:title" content="판다 마켓">
+    <meta
+        property="og:description"
+        content="일상의 모든 물건을 거래해보세요"
+    >
+    <meta property="og:url" content="https://vermillion-puffpuff-13b034.netlify.app/">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:image" content="images/index/logo.png">
+    <meta
+        name="twitter:title"
+        content="판다 마켓"
+    >
+    <meta
+        name="twitter:description"
+        content="일상의 모든 물건을 거래해보세요"
+    >
+    
+    <link rel="stylesheet" href="css/index.css">
+    <link rel="icon" href="images/index/favicon.ico">
 </head>
 <body>
      <header>
         <div class="header__content">
-            <a href="/"><img src="images/logo.png" alt="판다마켓 로고"></a>
+            <a href="/"><img src="images/index/logo.png" alt="판다마켓 로고"></a>
             <button onclick="location.href='/login.html'">로그인</button>
         </div>
      </header>
@@ -27,12 +46,12 @@
                         <button onclick="location.href='/items'">구경하러 가기</button>
                     </div>
                 </div>
-                    <img src="images/visual.png" alt="visual">
+                    <img src="images/index/visual.png" alt="visual">
             </div>
         </section>
         <section class="features">
             <div class="features__content">
-                <img src="images/hot-item.png" alt="hot-item-img">
+                <img src="images/index/hot-item.png" alt="hot-item-img">
                 <div>
                     <p class="features__subtitle">Hot Item</p>
                     <h1>
@@ -57,10 +76,10 @@
                         쉽게 찾아보세요
                     </p>
                 </div>
-                <img src="images/search.png" alt="search-img">
+                <img src="images/index/search.png" alt="search-img">
             </div>
             <div class="features__content">
-                <img src="images/register.png" alt="register-img">
+                <img src="images/index/register.png" alt="register-img">
                 <div>
                     <p class="features__subtitle">Register</p>
                     <h1>
@@ -80,7 +99,7 @@
                     믿을 수 있는<br>
                     판다마켓 중고 거래
                 </h1>
-                <img src="images/outro.png" alt="outro-img">
+                <img src="images/index/outro.png" alt="outro-img">
             </div>
         </section>
      </main>
@@ -92,10 +111,10 @@
                 <a href="/faq"><p>FAQ</p></a>
             </div>
             <div class="footer__sns">
-                <a href="https://www.facebook.com" target="_blank"><img src="images/facebook.png" alt="facebook"></a>
-                <a href="https://www.twitter.com" target="_blank"><img src="images/twitter.png" alt="twitter"></a>
-                <a href="https://www.youtube.com" target="_blank"><img src="images/youtube.png" alt="youtube"></a>
-                <a href="https://www.instagram.com" target="_blank"><img src="images/instagram.png" alt="instagram"></a>
+                <a href="https://www.facebook.com" target="_blank"><img src="images/index/facebook.png" alt="facebook"></a>
+                <a href="https://www.twitter.com" target="_blank"><img src="images/index/twitter.png" alt="twitter"></a>
+                <a href="https://www.youtube.com" target="_blank"><img src="images/index/youtube.png" alt="youtube"></a>
+                <a href="https://www.instagram.com" target="_blank"><img src="images/index/instagram.png" alt="instagram"></a>
             </div>
         </div>
      </footer>

--- a/login.html
+++ b/login.html
@@ -5,25 +5,48 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <link rel="stylesheet" href="member/style.css">
-    <link rel="icon" href="images/favicon.ico">
+
+    <meta property="og:image" content="images/index/logo.png">
+    <meta property="og:title" content="판다 마켓 · 로그인">
+    <meta
+        property="og:description"
+        content="일상의 모든 물건을 거래해보세요"
+    >
+    <meta property="og:url" content="https://vermillion-puffpuff-13b034.netlify.app/login.html">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:image" content="images/index/logo.png">
+    <meta
+        name="twitter:title"
+        content="판다 마켓 · 로그인"
+    >
+    <meta
+        name="twitter:description"
+        content="일상의 모든 물건을 거래해보세요"
+    >
+
+    <link rel="stylesheet" href="css/login.css">
+    <link rel="icon" href="images/index/favicon.ico">
 </head>
 <body>
     <main>
-      <a class="logo" href="/"><img src="member/signup_images/logo.png" alt="판다마켓 로고"></a>
+      <a class="logo" href="/"><img src="images/login/logo.png" alt="판다마켓 로고"></a>
       <form action="/" mothod="POST">
         <label for="email">이메일</label>
         <input type="email" placeholder="이메일을 입력해주세요." id="email" name="email" required>
-        <label for="password">비밀번호</label>
-        <input class="password" type="password" placeholder="비밀번호를 입력해주세요." id="password" name="password" required minlength="7">
+        <div class="password">
+          <label for="password">비밀번호</label>
+          <input type="password" placeholder="비밀번호를 입력해주세요." id="password" name="password" required minlength="7">
+          <img class="password__visibility password__visibility--on" src="images/login/btn_visibility_on.png" alt="비밀번호 보기">
+          <img class="password__visibility password__visibility--off" src="images/login/btn_visibility_off.png" alt="비밀번호 안 보기">
+        </div>
         <button class="button--disabled" type="submit" disabled="true">로그인</button>
         <button class="button--enabled" type="submit">로그인</button>
       </form>
         <div class="snslogin">
           간편 로그인하기
           <div class="snslogin__logo">
-            <a href="https://www.google.com"><img src="member/signup_images/google.png" alt="구글 로그인"></a>
-            <a href="https://www.kakaocorp.com/page"><img src="member/signup_images/kakao.png" alt="카카오 로그인"></a>
+            <a href="https://www.google.com"><img src="images/login/google.png" alt="구글 로그인"></a>
+            <a href="https://www.kakaocorp.com/page"><img src="images/login/kakao.png" alt="카카오 로그인"></a>
         </div>
         </div>
         <div class="member">

--- a/signup.html
+++ b/signup.html
@@ -5,29 +5,56 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <link rel="stylesheet" href="member/style.css">
-    <link rel="icon" href="images/favicon.ico">
+
+    <meta property="og:image" content="images/index/logo.png">
+    <meta property="og:title" content="판다 마켓 · 회원가입">
+    <meta
+        property="og:description"
+        content="일상의 모든 물건을 거래해보세요"
+    >
+    <meta property="og:url" content="https://vermillion-puffpuff-13b034.netlify.app/signup">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:image" content="images/index/logo.png">
+    <meta
+        name="twitter:title"
+        content="판다 마켓 · 회원가입"
+    >
+    <meta
+        name="twitter:description"
+        content="일상의 모든 물건을 거래해보세요"
+    >
+
+    <link rel="stylesheet" href="css/login.css">
+    <link rel="icon" href="images/index/favicon.ico">
 </head>
 <body>
     <main>
-      <a class="logo" href="/"><img src="member/signup_images/logo.png" alt="판다마켓 로고"></a>
+      <a class="logo" href="/"><img src="images/login/logo.png" alt="판다마켓 로고"></a>
       <form action="/" mothod="POST">
         <label for="email">이메일</label>
         <input type="email" placeholder="이메일을 입력해주세요." id="email" name="email" required>
         <label for="text">닉네임</label>
         <input type="text" placeholder="닉네임을 입력해주세요." id="text" name="text" required>
-        <label for="password">비밀번호</label>
-        <input class="password" type="password" placeholder="비밀번호를 입력해주세요." id="password" name="password" required minlength="7">
-        <label for="check_password">비밀번호 확인</label>
-        <input class="password" type="password" placeholder="비밀번호를 다시 한 번 입력해주세요." id="check_password" name="check_password" required minlength="7">
+        <div class="password">
+          <label for="password">비밀번호</label>
+          <input type="password" placeholder="비밀번호를 입력해주세요." id="password" name="password" required minlength="7">
+          <img class="password__visibility password__visibility--on" src="images/login/btn_visibility_on.png" alt="비밀번호 보기">
+          <img class="password__visibility password__visibility--off" src="images/login/btn_visibility_off.png" alt="비밀번호 안 보기">
+        </div>
+          <div class="password">
+          <label for="check_password">비밀번호 확인</label>
+          <input class="password" type="password" placeholder="비밀번호를 다시 한 번 입력해주세요." id="check_password" name="check_password" required minlength="7">
+          <img class="password__visibility password__visibility--on" src="images/login/btn_visibility_on.png" alt="비밀번호 보기">
+          <img class="password__visibility password__visibility--off" src="images/login/btn_visibility_off.png" alt="비밀번호 안 보기">
+        </div>
         <button class="button--disabled" type="submit" disabled="true">회원가입</button>
         <button class="button--enabled" type="submit">회원가입</button>
       </form>
         <div class="snslogin">
           간편 로그인하기
           <div class="snslogin__logo">
-            <a href="https://www.google.com"><img src="member/signup_images/google.png" alt="구글 로그인"></a>
-            <a href="https://www.kakaocorp.com/page"><img src="member/signup_images/kakao.png" alt="카카오 로그인"></a>
+            <a href="https://www.google.com"><img src="images/login/google.png" alt="구글 로그인"></a>
+            <a href="https://www.kakaocorp.com/page"><img src="images/login/kakao.png" alt="카카오 로그인"></a>
         </div>
         </div>
         <div class="member">


### PR DESCRIPTION
## 요구사항

### 기본

공통
- [x] 브라우저에 현재 보이는 화면의 영역(viewport) 너비를 기준으로 분기되는 반응형 디자인을 적용합니다.
        - PC: 1200px 이상
        - Tablet: 768px 이상 ~ 1199px 이하
        - Mobile: 375px 이상 ~ 767px 이하
        - 375px 미만 사이즈의 디자인은 고려하지 않습니다.

랜딩 페이지

- [x] Tablet 사이즈로 작아질 때 “판다마켓” 로고의 왼쪽에 여백 24px, “로그인” 버튼 오른쪽 여백 24px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [x] Mobile 사이즈로 작아질 때 “판다마켓” 로고의 왼쪽에 여백 16px, “로그인” 버튼 오른쪽 여백 16px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [x] 화면 영역이 줄어들면 “Privacy Policy”, “FAQ”, “codeit-2024”이 있는 영역과 SNS 아이콘들이 있는 영역의 간격이 줄어듭니다.

로그인, 회원가입 페이지 공통

- [x] Tablet 사이즈에서 내부 디자인은 PC사이즈와 동일합니다.
- [x] Mobile 사이즈에서 좌우 여백 16px 제외하고 내부 요소들이 너비를 모두 차지합니다.
- [x] Mobile 사이즈에서 내부 요소들의 너비는 기기의 너비가 커지는 만큼 커지지만 400px을 넘지 않습니다.

### 심화

- [x] 페이스북, 카카오톡, 디스코드, 트위터 등 SNS에서 Linkbrary 랜딩 페이지(“/”) 공유 시 좌측 예시와 같은 미리보기를 볼 수 있도록 랜딩 페이지 메타 태그를 설정해 주세요.
- [x] 미리보기에서 제목은 “판다 마켓”, 설명은 “일상의 모든 물건을 거래해보세요”로 설정합니다.
- [x] 주소와 이미지는 자유롭게 설정하세요.

## 주요 변경사항

- 피그마에 작업된 디자인 기준으로 메인 페이지 반응형 작업했습니다.
- 비밀번호 눈 아이콘 position 절대값으로 재배치했습니다.

## 스크린샷

[스크린샷.zip](https://github.com/user-attachments/files/17077650/default.zip)

## 멘토에게

- https://vermillion-puffpuff-13b034.netlify.app/
- 메인 페이지에서 헤더랑 푸터 부분 css 파일을 따로 나누는 게 좋을지 여쭤보고 싶습니다! 추후 페이지가 많아질 경우 css 파일을 어떻게 나눠야 좋을지 궁금합니다.