### PR TITLE
[김도훈] sprint3

### DIFF
--- a/Sprint-Mission1/css/style.css
+++ b/Sprint-Mission1/css/style.css
@@ -103,6 +103,7 @@ header .inner-wrap .hd-container .login-btn {
   height: 48px;
   border-radius: 8px;
   background-color: var(--skyblue);
+  cursor: pointer;
 }
 
 header .inner-wrap .hd-container .login-btn a {
@@ -396,19 +397,50 @@ gap: 24px;
   width: 100%;
   height: 100%;
   cursor: pointer;
+  opacity: 0;
+  pointer-events: none;
+}
+.login-container .password-wrap .eyes-img-wrap .close-eyes.visible{
+  opacity: 1;
+  pointer-events: all;
+
 }
 .login-container .password-wrap .eyes-img-wrap .close-eyes img{
   width: 100%;
   height: 100%;
 }
-.login-container input {
-  border: none;
+.login-container .password-wrap .eyes-img-wrap .open-eyes{
   width: 100%;
+  cursor: pointer;
+  position: absolute;
+  top: 0;
+  opacity: 0;
+  pointer-events: none;
+}
+.login-container .password-wrap .eyes-img-wrap .open-eyes.visible{
+  opacity: 1;
+  pointer-events: all;
+}
+.login-container .password-wrap .eyes-img-wrap .open-eyes img{
+  width: 100%;
+}
+.error-message{
+  color: var(--red);
+  font-size: 14px;
+  padding: 8px 0px 0px 16px;
+}
+.login-container input {
+  border: 1px solid transparent;
+  width: 100%;
+}
+.login-container input.error{
+  border: 1px solid var(--red);
 }
 .login-container input:focus {
   outline: none;
   border: 2px solid var(--skyblue);
 }
+.login-container input:focus
 .login-container input::placeholder{
   color: var(--gray400);
   position: absolute;
@@ -532,8 +564,11 @@ flex-direction: column;
 gap: 24px;
 }
 .signup-container input {
-  border: none;
+  border: 1px solid transparent;
   width: 100%;
+}
+.signup-container input.error{
+  border: 1px solid var(--red);
 }
 .signup-container input:focus {
   outline: none;
@@ -568,6 +603,7 @@ gap: 24px;
   font-size: 1.25rem;
   color: var(--gray100);
   cursor: pointer;
+  
 
 }
 .signup-container .password-wrap{
@@ -585,8 +621,30 @@ gap: 24px;
   width: 100%;
   height: 100%;
   cursor: pointer;
+  opacity: 0;
+  pointer-events: none;
+}
+.signup-container .password-wrap .eyes-img-wrap .close-eyes.visible{
+  opacity: 1;
+  pointer-events: all;
 }
 .signup-container .password-wrap .eyes-img-wrap .close-eyes img{
+  width: 100%;
+  height: 100%;
+}
+.signup-container .password-wrap .eyes-img-wrap .open-eyes{
+  width: 100%;
+  cursor: pointer;
+  opacity: 0;
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+}
+.signup-container .password-wrap .eyes-img-wrap .open-eyes.visible{
+  opacity: 1;
+  pointer-events: all;
+}
+.signup-container .password-wrap .eyes-img-wrap .open-eyes img{
   width: 100%;
   height: 100%;
 }
@@ -605,10 +663,31 @@ gap: 24px;
   width: 100%;
   height: 100%;
   cursor: pointer;
+  opacity: 0;
+  pointer-events: none;
+}
+.signup-container .check-p-wrap .eyes-img-wrap .close-eyes.visible{
+  opacity: 1;
+  pointer-events: all;
 }
 .signup-container .check-p-wrap .eyes-img-wrap .close-eyes img{
   width: 100%;
   height: 100%;
+}
+.signup-container .check-p-wrap .eyes-img-wrap .open-eyes{
+  width: 100%;
+  cursor: pointer;
+  opacity: 0;
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+}
+.signup-container .check-p-wrap .eyes-img-wrap .open-eyes.visible{
+  opacity: 1;
+  pointer-events: all;
+}
+.signup-container .check-p-wrap .eyes-img-wrap .open-eyes img{
+  width: 100%;
 }
 
 

--- a/Sprint-Mission1/js/login.js
+++ b/Sprint-Mission1/js/login.js
@@ -1,0 +1,96 @@
+document.addEventListener("DOMContentLoaded", function () {
+  const emailInput = document.getElementById("pandaEmail");
+  const passwordInput = document.getElementById("pandaPassword");
+  const loginButton = document.getElementById("loginButton");
+  const emailError = document.getElementById("e-error");
+  const passwordError = document.getElementById("p-error");
+  const closeEyesbtn = document.querySelector(".close-eyes");
+  const openEyesbtn = document.querySelector(".open-eyes");
+
+
+
+  // 이메일 유효성 검사
+  function validateEmail() {
+    const emailValue = emailInput.value.trim();
+    emailError.textContent = "";
+    emailInput.classList.remove("error");
+
+    if (!emailValue) {
+      emailError.textContent = "이메일을 입력해주세요.";
+      emailInput.classList.add("error");
+      return false;
+    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(emailValue)) {
+      emailError.textContent = "잘못된 이메일 형식입니다.";
+      emailInput.classList.add("error");
+      return false;
+    }
+    return true;
+  }
+
+  // 비밀번호 유효성 검사
+  function validatePassword() {
+    const passwordValue = passwordInput.value.trim();
+    passwordError.textContent = "";
+    passwordInput.classList.remove("error");
+
+    if (!passwordValue) {
+      passwordError.textContent = "비밀번호를 입력해주세요.";
+      passwordInput.classList.add("error");
+      return false;
+    } else if (passwordValue.length < 8) {
+      passwordError.textContent = "비밀번호를 8자 이상 입력해주세요.";
+      passwordInput.classList.add("error");
+      return false;
+    }
+    return true;
+  }
+  // 비밀번호 숨김 상태 확인 함수
+  function togglePasswordVisibility(passwordType, passclosebtn, passopenbtn) {
+    const inPasswordType = passwordType.getAttribute('type') === 'password'; 
+
+    if (inPasswordType) {
+      passwordType.setAttribute('type', 'text'); 
+      passclosebtn.classList.remove('visible');
+      passopenbtn.classList.add('visible');
+    } else {
+      passwordType.setAttribute('type', 'password'); 
+      passclosebtn.classList.add('visible');
+      passopenbtn.classList.remove('visible');
+    }
+  }
+
+  closeEyesbtn.addEventListener('click', () => togglePasswordVisibility(passwordInput, closeEyesbtn, openEyesbtn));
+  openEyesbtn.addEventListener('click', () => togglePasswordVisibility(passwordInput, closeEyesbtn, openEyesbtn));
+
+
+  // 로그인 버튼 활성화/비활성화
+  function toggleLoginButton() {
+    if (validateEmail() && validatePassword()) {
+      loginButton.classList.remove("disabled");
+      loginButton.disabled = false;
+    } else {
+      loginButton.classList.add("disabled");
+      loginButton.disabled = true;
+    }
+  }
+
+  // 이메일 focus out 이벤트
+  emailInput.addEventListener("focusout", function () {
+    validateEmail();
+    toggleLoginButton();
+  });
+
+  // 비밀번호 focus out 이벤트
+  passwordInput.addEventListener("focusout", function () {
+    validatePassword();
+    toggleLoginButton();
+  });
+
+  // 로그인 버튼 클릭 시 폼 제출 및 페이지 이동
+  document.getElementById("loginForm").addEventListener("submit", function (event) {
+    event.preventDefault();
+    if (validateEmail() && validatePassword()) {
+      window.location.href = "/items.html";
+    }
+  });
+});

--- a/Sprint-Mission1/js/signup.js
+++ b/Sprint-Mission1/js/signup.js
@@ -1,0 +1,123 @@
+document.addEventListener("DOMContentLoaded", function () {
+  const emailInput = document.getElementById("signupEmail");
+  const passwordInput = document.getElementById("singupPassword");
+  const chpasswordInput = document.getElementById("checkPassword");
+  const signButton = document.getElementById("singupButton");
+  const emailError = document.getElementById("e-error");
+  const passwordError = document.getElementById("p-error");
+  const chpasswordError = document.getElementById("cp-error");
+  const passcloseEyesbtn = document.querySelector(".password-wrap .close-eyes");
+  const passopenEyesbtn = document.querySelector(".password-wrap .open-eyes");
+  const chcloseEyesbtn = document.querySelector(".check-p-wrap .close-eyes");
+  const chopenEyesbtn = document.querySelector(".check-p-wrap .open-eyes");
+
+
+  // 이메일 유효성 검사
+  function validateEmail() {
+    const emailValue = emailInput.value.trim();
+    emailError.textContent = "";
+    emailInput.classList.remove("error");
+
+    if (!emailValue) {
+      emailError.textContent = "이메일을 입력해주세요.";
+      emailInput.classList.add("error");
+      return false;
+    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(emailValue)) {
+      emailError.textContent = "잘못된 이메일 형식입니다.";
+      emailInput.classList.add("error");
+      return false;
+    }
+    return true;
+  }
+
+  // 비밀번호 유효성 검사
+  function validatePassword() {
+    const passwordValue = passwordInput.value.trim();
+    passwordError.textContent = "";
+    passwordInput.classList.remove("error");
+
+    if (!passwordValue) {
+      passwordError.textContent = "비밀번호를 입력해주세요.";
+      passwordInput.classList.add("error");
+      return false;
+    } else if (passwordValue.length < 8) {
+      passwordError.textContent = "비밀번호를 8자 이상 입력해주세요.";
+      passwordInput.classList.add("error");
+      return false;
+    }
+    return true;
+  }
+  // 비밀번호 확인 유효성 검사
+  function confirmPassword() {
+    const passwordValue = passwordInput.value.trim();
+    const chpasswordValue = chpasswordInput.value.trim();
+    chpasswordError.textContent = "";
+    chpasswordInput.classList.remove("error");
+
+    if (passwordValue !== chpasswordValue) {
+      chpasswordError.textContent = "비밀번호가 일치하지 않습니다";
+      chpasswordInput.classList.add("error");
+      return false;
+    }
+    return true;
+
+  }
+  // 비밀번호 숨김 상태 확인 함수
+  function togglePasswordVisibility(passwordType, passclosebtn, passopenbtn) {
+    const inPasswordType = passwordType.getAttribute('type') === 'password';
+
+    if (inPasswordType) {
+      passwordType.setAttribute('type', 'text');
+      passclosebtn.classList.remove('visible');
+      passopenbtn.classList.add('visible');
+    } else {
+      passwordType.setAttribute('type', 'password');
+      passclosebtn.classList.add('visible');
+      passopenbtn.classList.remove('visible');
+    }
+  }
+
+  // 각 버튼에 대한 클릭 이벤트 핸들러
+  passcloseEyesbtn.addEventListener('click', () => togglePasswordVisibility(passwordInput, passcloseEyesbtn, passopenEyesbtn));
+  passopenEyesbtn.addEventListener('click', () => togglePasswordVisibility(passwordInput, passcloseEyesbtn, passopenEyesbtn));
+
+  chcloseEyesbtn.addEventListener('click', () => togglePasswordVisibility(chpasswordInput, chcloseEyesbtn, chopenEyesbtn));
+  chopenEyesbtn.addEventListener('click', () => togglePasswordVisibility(chpasswordInput, chcloseEyesbtn, chopenEyesbtn));
+
+
+  // 회원가입 버튼 활성화/비활성화
+  function toggleSignupButton() {
+    if (validateEmail() && validatePassword() && confirmPassword()) {
+      signButton.classList.remove("disabled");
+      signButton.disabled = false;
+    } else {
+      signButton.classList.add("disabled");
+      signButton.disabled = true;
+    }
+  }
+
+  // 이메일 focus out 이벤트
+  emailInput.addEventListener("focusout", function () {
+    validateEmail();
+    toggleSignupButton();
+  });
+
+  // 비밀번호 focus out 이벤트
+  passwordInput.addEventListener("focusout", function () {
+    validatePassword();
+    toggleSignupButton();
+  });
+  // 비밀번호 확인 focus out 이벤트
+  chpasswordInput.addEventListener("focusout", function () {
+    confirmPassword();
+    toggleSignupButton();
+  });
+
+  // 회원가입 버튼 클릭 시 폼 제출 및 페이지 이동
+  document.getElementById("signForm").addEventListener("submit", function (event) {
+    event.preventDefault();
+    if (validateEmail() && validatePassword() && confirmPassword()) {
+      window.location.href = "/login.html";
+    }
+  });
+});

--- a/Sprint-Mission1/login.html
+++ b/Sprint-Mission1/login.html
@@ -7,6 +7,7 @@
     <title>판다마켓-로그인</title>
     <link rel="stylesheet" href="./css/style.css">
     <link rel="stylesheet" href="./css/font.css">
+    <script src="./js/login.js"></script>
 </head>
 
 <body>
@@ -18,24 +19,29 @@
                     <div class="logo-txt"><img src="./images/logo/logo_txt.png" alt="로고텍스트"></div>
                 </a>
             </div>
-            <form action="" name="panda-login">
+            <form id="loginForm" action="" name="panda-login">
                 <div class="form-wrap">
                     <div class="p-email-wrap">
                         <label for="pandaEmail">이메일</label>
                         <input type="email" placeholder="이메일을 입력해주세요" name="useremail" id="pandaEmail" required>
+                        <div id="e-error" class="error-message"></div>
                     </div>
                     <div class="p-password-wrap">
                         <label for="pandaPassword">비밀번호</label>
                         <div class="password-wrap">
                             <input type="password" placeholder="비밀번호를 입력해주세요" name="userpassword" id="pandaPassword" required>
                             <div class="eyes-img-wrap">
-                                <div class="close-eyes">
+                                <div class="close-eyes visible">
                                     <img src="./images/icons/visibility.png" alt="클릭시비밀번호보기">
+                                </div>
+                                <div class="open-eyes">
+                                    <img src="./images/icons/visible.png" alt="클릭시비밀번호숨기기">
                                 </div>
                             </div>
                         </div>
+                        <div id="p-error" class="error-message"></div>
                     </div>
-                    <button type="submit" class="login-btn">로그인</button>
+                    <button type="submit" id="loginButton" class="login-btn" disabled>로그인</button>
                     <div class="quick-login-box">
                         <p>간편 로그인하기</p>
                         <div class="quick-sns-box">

--- a/Sprint-Mission1/signup.html
+++ b/Sprint-Mission1/signup.html
@@ -7,6 +7,7 @@
     <title>판다마켓-회원가입</title>
     <link rel="stylesheet" href="./css/style.css">
     <link rel="stylesheet" href="./css/font.css">
+    <script src="./js/signup.js"></script>
 </head>
 
 <body>
@@ -19,11 +20,12 @@
                     <div class="logo-txt"><img src="./images/logo/logo_txt.png" alt="로고텍스트"></div>
                 </a>
             </div>
-            <form action="" name="signup">
+            <form id="signForm" action="" name="signup">
                 <div class="signup-wrap">
                     <div class="signup-email">
                         <label for="signupEmail">이메일</label>
                         <input type="email" name="signupEmail" id="signupEmail" placeholder="이메일을 입력해주세요" required>
+                        <div id="e-error" class="error-message"></div>
                     </div>
                     <div class="signup-name">
                         <label for="signupName">닉네임</label>
@@ -34,24 +36,32 @@
                         <div class="password-wrap">
                             <input type="password" placeholder="비밀번호를 입력해주세요" name="singupPassword" id="singupPassword" required>
                             <div class="eyes-img-wrap">
-                                <div class="close-eyes">
+                                <div class="close-eyes visible">
                                     <img src="./images/icons/visibility.png" alt="클릭시비밀번호보기">
+                                </div>
+                                <div class="open-eyes">
+                                    <img src="./images/icons/visible.png" alt="클릭시비밀번호숨기기">
                                 </div>
                             </div>
                         </div>
+                        <div id="p-error" class="error-message"></div>
                     </div>
                     <div class="check-password-wrap">
                         <label for="checkPassword">비밀번호 확인</label>
                         <div class="check-p-wrap">
                             <input type="password" placeholder="비밀번호를 다시 한 번 입력해주세요" name="checkPassword" id="checkPassword" required>
                             <div class="eyes-img-wrap">
-                                <div class="close-eyes">
+                                <div class="close-eyes visible">
                                     <img src="./images/icons/visibility.png" alt="클릭시비밀번호보기">
+                                </div>
+                                <div class="open-eyes">
+                                    <img src="./images/icons/visible.png" alt="클릭시비밀번호숨기기">
                                 </div>
                             </div>
                         </div>
+                        <div id="cp-error" class="error-message"></div>
                     </div>
-                    <button type="submit" class="singup-btn">회원가입</button>
+                    <button type="submit" id="singupButton" class="singup-btn" disabled>회원가입</button>
                     <div class="quick-login-box">
                         <p>간편 로그인하기</p>
                         <div class="quick-sns-box">


### PR DESCRIPTION
## 요구사항

### 기본

브라우저에 현재 보이는 화면의 영역(viewport) 너비를 기준으로 분기되는 반응형 디자인을 적용합니다.
PC: 1200px 이상
Tablet: 768px 이상 ~ 1199px 이하
Mobile: 375px 이상 ~ 767px 이하
375px 미만 사이즈의 디자인은 고려하지 않습니다
랜딩 페이지

Tablet 사이즈로 작아질 때 “판다마켓” 로고의 왼쪽에 여백 24px, “로그인” 버튼 오른쪽 여백 24px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
Mobile 사이즈로 작아질 때 “판다마켓” 로고의 왼쪽에 여백 16px, “로그인” 버튼 오른쪽 여백 16px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
화면 영역이 줄어들면 “Privacy Policy”, “FAQ”, “codeit-2024”이 있는 영역과 SNS 아이콘들이 있는 영역의 간격이 줄어듭니다.
로그인, 회원가입 페이지 공통

Tablet 사이즈에서 내부 디자인은 PC사이즈와 동일합니다.
Mobile 사이즈에서 좌우 여백 16px 제외하고 내부 요소들이 너비를 모두 차지합니다.
Mobile 사이즈에서 내부 요소들의 너비는 기기의 너비가 커지는 만큼 커지지
![FireShot Capture 175 - 판다마켓-로그인 - 127 0 0 1](https://github.com/user-attachments/assets/cf48fecd-bc1f-4cd6-8eea-48d9c46a2229)
![FireShot Capture 174 - 판다마켓-회원가입 - 127 0 0 1](https://github.com/user-attachments/assets/0c6061c2-8116-4fe3-ab1b-a49a6384edf6)
만 400px을 넘지 않습니다.

### 심화

페이스북, 카카오톡, 디스코드, 트위터 등 SNS에서 Linkbrary 랜딩 페이지(“/”) 공유 시 좌측 예시와 같은 미리보기를 볼 수 있도록 랜딩 페이지 메타 태그를 설정해 주세요.
미리보기에서 제목은 “판다 마켓”, 설명은 “일상의 모든 물건을 거래해보세요”로 설정합니다.
주소와 이미지는 자유롭게 설정하세요.

## 주요 변경사항

- js파일추가

## 멘토에게

- 스프린트미션4을 미리 완성을 했습니다. 확인부탁드립니다!
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.

## 링크

https://idyllic-halva-3fd990.netlify.app/
https://idyllic-halva-3fd990.netlify.app/login
https://idyllic-halva-3fd990.netlify.app/signup

