### PR TITLE
[석지우] Sprint3

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
         <meta charset="utf-8">
         <title>판다마켓</title>
         <link rel="stylesheet" href="style.css">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
     </head>
     <body>
  

--- a/index.html
+++ b/index.html
@@ -5,6 +5,19 @@
         <title>판다마켓</title>
         <link rel="stylesheet" href="style.css">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+        <!-- 랜딩 페이지 메타 태그 -->
+        <meta property="og:type" content="website">
+        <meta property="og:url" content="https://paaaaaandamarket.netlify.app/">
+        <meta property="og:title" content="판다 마켓">
+        <meta property="og:description" content="일상의 모든 물건을 거래해보세요. 판다 마켓에서 쉽고 빠르게 거래를 시작하세요.">
+        <meta property="og:image" content="img/landing/langing-page.png">
+        <meta name="twitter:card" content="summary_large_image">
+        <meta name="twitter:url" content="https://paaaaaandamarket.netlify.app/">
+        <meta name="twitter:title" content="판다 마켓">
+        <meta name="twitter:description" content="일상의 모든 물건을 거래해보세요. 판다 마켓에서 쉽고 빠르게 거래를 시작하세요.">
+        <meta name="twitter:image" content="img/landing/langing-page.png">
+        
     </head>
     <body>
  

--- a/index.html
+++ b/index.html
@@ -16,21 +16,21 @@
         </header>
 
         <main>
-            <section class="home-top">
-                <div class="home-top-all">
-                    <div class="home-top-content">
+            <section class="hero-section">
+                <div class="hero-content">
+                    <div class="hero-text">
                         <p>일상의 모든 물건을 <p>
                         거래해 보세요</h1>
-                        <a href="items" class="home-top-button">구경하러 가기</a> 
+                        <a href="items" class="cta-button">구경하러 가기</a> 
                     </div>
-                    <img class="home-top-img" alt="home-top-img" src="img/home/Img_home_top.png">
+                    <img class="hero-image" alt="home-top-img" src="img/home/Img_home_top.png">
                 </div>
             </section>
 
-            <section class="home-first">
-                <div class="home-first-all">
-                    <img src="img/home/Img_home_01.png" alt="home-first-img">
-                    <div class="home-first-content">
+            <section class="popular-items-section">
+                <div class="popular-items-content">
+                    <img src="img/home/Img_home_01.png" alt="popular-items-image">
+                    <div class="item-details">
                         <div class="badge hot-item">Hot item</div>
                         <div class="sub">
                             <p class="subtitle">인기 상품을 <br>
@@ -42,9 +42,9 @@
                 </div>
             </section>
 
-            <section class="home-second">
-                <div class="home-second-all">
-                    <div class="home-second-content">
+            <section class="search-items-section">
+                <div class="search-items-content">
+                    <div class="item-details">
                         <div class="badge search">Search</div>
                         <div class="sub">
                             <p class="subtitle">구매를 원하는<br>
@@ -53,14 +53,14 @@
                             쉽게 찾아보세요</p>
                         </div>
                     </div>
-                    <img src="img/home/Img_home_02.png" alt="home-second-img">
+                    <img src="img/home/Img_home_02.png" alt="search-items-image">
                 </div>
             </section>
 
-            <section class="home-third">
-                <div class="home-third-all">
-                    <img src="img/home/Img_home_03.png" alt="home-third-img">
-                    <div class="home-third-content">
+            <section class="register-items-section">
+                <div class="register-items-content">
+                    <img src="img/home/Img_home_03.png" alt="register-items-image">
+                    <div class="item-details">
                         <div class="badge register">Register</div>
                         <div class="sub">
                             <p class="subtitle">판매를 원하는<br>
@@ -75,23 +75,23 @@
             <!-- self close를 했을 때 오류남 -->
             <div class="bottom-grayBox"></div>
 
-            <section class="home-bottom">
-                <div class="home-bottom-all">
+            <section class="trust-section">
+                <div class="trust-content">
                     <p>믿을 수 있는<br>
                     판다마켓 중고 거래</p>
-                    <img class="home-bottom-img" src="img/home/Img_home_bottom.png" alt="home-bottom-img">  
+                    <img class="trust-image" src="img/home/Img_home_bottom.png" alt="trust-section-image">  
                 </div>
             </section>
         </main>
 
         <footer>
-            <section class="footer-all">
-                <div class="footer-first">@codeit - 2024</div>
-                <div class="footer-second"> 
+            <section class="footer-section">
+                <div class="footer-content">@codeit - 2024</div>
+                <div class="footer-policy-faq"> 
                     <a href="privacy">Privacy Policy</a>
                     <a href="faq">FAQ</a>     
                 </div>   
-                <div class="footer-third">
+                <div class="footer-sns">
                     <a href="https://www.facebook.com"><img src="img/SNS/ic_facebook.png" alt="facebook-logo"></a>
                     <a href="https://twitter.com"><img src="img/SNS/ic_twitter.png" alt="twitter-logo"></a>
                     <a href="https://www.youtube.com"><img src="img/SNS/ic_youtube.png" alt="youtube-logo"></a>

--- a/index.html
+++ b/index.html
@@ -19,8 +19,8 @@
             <section class="hero-section">
                 <div class="hero-content">
                     <div class="hero-text">
-                        <p>일상의 모든 물건을 <p>
-                        거래해 보세요</h1>
+                        <p>일상의 모든 물건을 <br class="onlyPC">
+                        거래해 보세요</p>
                         <a href="items" class="cta-button">구경하러 가기</a> 
                     </div>
                     <img class="hero-image" alt="home-top-img" src="img/home/Img_home_top.png">
@@ -33,7 +33,7 @@
                     <div class="item-details">
                         <div class="badge hot-item">Hot item</div>
                         <div class="sub">
-                            <p class="subtitle">인기 상품을 <br>
+                            <p class="subtitle">인기 상품을 <br class="onlyPC">
                                 확인해 보세요</p>
                             <p class="sub-content">가장 HOT한 중고거래 물품을<br>  
                             판다 마켓에서 확인해 보세요</p>
@@ -47,7 +47,7 @@
                     <div class="item-details">
                         <div class="badge search">Search</div>
                         <div class="sub">
-                            <p class="subtitle">구매를 원하는<br>
+                            <p class="subtitle">구매를 원하는<br class="onlyPC">
                                 상품을 검색하세요</p>
                             <p class="sub-content">구매하고 싶은 물품은 검색해서<br>
                             쉽게 찾아보세요</p>
@@ -63,7 +63,7 @@
                     <div class="item-details">
                         <div class="badge register">Register</div>
                         <div class="sub">
-                            <p class="subtitle">판매를 원하는<br>
+                            <p class="subtitle">판매를 원하는<br class="onlyPC">
                                 상품을 등록하세요</p>
                             <p class="sub-content">어떤 물건이든 판매하고 싶은 상품을<br>
                             쉽게   등록하세요</p>

--- a/login.html
+++ b/login.html
@@ -4,6 +4,7 @@
         <meta charset="utf-8">
         <title>로그인</title>
         <link rel="stylesheet" href="loginStyle.css">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
     </head>
     <body>
         <form class="login">

--- a/login.html
+++ b/login.html
@@ -12,15 +12,15 @@
             </a>
             <section class="loginmain">
                 <div class="inputarea">
-                    <label>이메일</label>
+                    <label for="email">이메일</label>
                     <br>
-                    <input name="useremail" type="email" placeholder="이메일을 입력해주세요">
+                    <input id="email" name="useremail" type="email" placeholder="이메일을 입력해주세요">
                 </div>
                 <div class="inputarea">
-                    <label>비밀번호</label>
+                    <label for="password">비밀번호</label>
                     <br>
                     <div class="input-container">
-                        <input name="userpassword" type="password" placeholder="비밀번호를 입력해주세요">
+                        <input id="password" name="userpassword" type="password" placeholder="비밀번호를 입력해주세요">
                         <img class="password-icon" src="img/input-icon/eye-off.png" alt="passwordicon">
                     </div>
                 </div>

--- a/login.html
+++ b/login.html
@@ -24,7 +24,7 @@
                         <img class="password-icon" src="img/input-icon/eye-off.png" alt="passwordicon">
                     </div>
                 </div>
-                <a href="./login.html" class="login-btn">로그인</a>
+                <button type='submit' class="login-btn">로그인</button>
                 <div class="simple-login">
                     <div class="simple-login-in">
                         <p>간편 로그인하기</p>

--- a/loginStyle.css
+++ b/loginStyle.css
@@ -134,3 +134,49 @@ input:focus {
 .firstuser a {
     color: var(--blue);
 }
+
+
+/* PC */
+@media (min-width: 1200px) {
+}
+
+/* Tablet */
+@media (min-width: 768px) and (max-width: 1199px) {
+}
+
+/* Mobile */
+@media (min-width: 375px) and (max-width: 767px) {
+    .login{
+        padding: 0 16px;
+    }
+
+    .loginlogo{
+        width: 65%;
+    }
+
+    label{
+        font-size: 14px;
+        margin-bottom: 10px;
+    }
+
+    input{
+        width: 100%;
+        max-width: 400px;
+        margin: 0 auto;
+        padding: 16px 0;
+        margin-top: 10px;
+    }
+
+    ::placeholder{
+        padding: 24px;
+    }
+
+    .login-btn{
+        width: 100%;
+    }
+
+    .simple-login-in{
+        width: 100%;
+        padding: 0 23px;
+    }
+}

--- a/loginStyle.css
+++ b/loginStyle.css
@@ -1,6 +1,5 @@
 @import "reset.css";
 
-
 @font-face {
     font-family: 'Pretendard-Regular';
     src: url('https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff') format('woff');
@@ -15,7 +14,7 @@
     --gray-400: #9CA3AF;
     --gray-200: #E5E7EB;
     --gray-100: #F3F4F6;
-    --gray-50:  #F9FAFB;
+    --gray-50: #F9FAFB;
 
     --blue: #3692FF;
 }
@@ -29,7 +28,7 @@ html {
 }
 
 .loginlogo {
-    width: 24.75rem;
+    width: 25rem;
     display: flex;
     align-items: center;
     margin: 0 auto;
@@ -37,28 +36,28 @@ html {
 }
 
 .inputarea {
-    margin-bottom: 1.5rem;
+    margin-bottom: 2rem;
     position: relative;
 }
 
 label {
-    font-size: 1.125rem;
+    font-size: 1.25rem;
     font-weight: 700;
 }
 
 input {
     width: 37rem;
-    height: 1.625rem;
+    height: 2rem;
     padding: 1rem 1.5rem;
     background-color: var(--gray-100);
     border: none;
     outline: none;
-    border-radius: 0.75rem;
+    border-radius: 1rem;
     margin-top: 1rem;
 }
 
 .input-container {
-    position: relative; 
+    position: relative;
     display: flex;
     align-items: center;
 }
@@ -74,25 +73,25 @@ input:focus {
 
 .password-icon {
     position: absolute;
-    width: 1.375rem;
-    right: 1.5625rem;
+    width: 1.5rem;
+    right: 1.5rem;
     top: 50%;
 }
 
 .login-btn {
-    display: flex; 
+    display: flex;
     width: 40rem;
-    height: 3.5rem;
+    height: 4rem;
     background-color: var(--gray-400);
     border-radius: 2.5rem;
     color: var(--gray-100);
-    font-size: 1.25rem;
+    font-size: 1.5rem;
     font-weight: 600;
     align-items: center;
     justify-content: center;
     text-decoration: none;
     border: none;
-    margin-bottom: 1.5rem;
+    margin-bottom: 2rem;
     cursor: pointer;
 }
 
@@ -101,13 +100,13 @@ input:focus {
     justify-content: center;
     align-items: center;
     background-color: #E6F2FF;
-    height: 4.625rem;
-    border-radius: 0.5rem; 
-    margin-bottom: 1.5rem;
+    height: 5rem;
+    border-radius: 0.5rem;
+    margin-bottom: 2rem;
 }
 
 .simple-login-in {
-    width: 37.125rem;
+    width: 37rem;
     display: flex;
     align-items: center;
     font-size: 1rem;
@@ -121,12 +120,12 @@ input:focus {
 }
 
 .login-icon img {
-    width: 2.625rem;
+    width: 3rem;
 }
 
 .firstuser {
     text-align: center;
-    font-size: 0.875rem;
+    font-size: 1rem;
     font-weight: 500;
     color: var(--gray-800);
 }
@@ -135,48 +134,46 @@ input:focus {
     color: var(--blue);
 }
 
-
 /* PC */
-@media (min-width: 1200px) {
-}
+@media (min-width: 1200px) {}
 
 /* Tablet */
-@media (min-width: 768px) and (max-width: 1199px) {
-}
+@media (min-width: 768px) and (max-width: 1199px) {}
 
 /* Mobile */
 @media (min-width: 375px) and (max-width: 767px) {
-    .login{
-        padding: 0 16px;
+    .login {
+        padding: 0 1rem;
+        margin-top: 10rem;
     }
 
-    .loginlogo{
+    .loginlogo {
         width: 65%;
     }
 
-    label{
-        font-size: 14px;
-        margin-bottom: 10px;
+    label {
+        font-size: 1rem;
+        margin-bottom: 1rem;
     }
 
-    input{
+    input {
         width: 100%;
-        max-width: 400px;
+        max-width: 25rem;
         margin: 0 auto;
-        padding: 16px 0;
-        margin-top: 10px;
+        padding: 1rem 0;
+        margin-top: 1rem;
     }
 
-    ::placeholder{
-        padding: 24px;
+    ::placeholder {
+        padding: 1rem;
     }
 
-    .login-btn{
+    .login-btn {
         width: 100%;
     }
 
-    .simple-login-in{
+    .simple-login-in {
         width: 100%;
-        padding: 0 23px;
+        padding: 0 1.5rem;
     }
 }

--- a/signup.html
+++ b/signup.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-    <head>ㅇ
+    <head>
         <meta charset="utf-8">
         <title>회원가입</title>
         <link rel="stylesheet" href="loginStyle.css">

--- a/signup.html
+++ b/signup.html
@@ -12,28 +12,28 @@
             </a>
             <section class="loginmain">
                 <div class="inputarea">
-                    <label>이메일</label>
+                    <label for="email">이메일</label>
                     <br>
-                    <input name="useremail" type="email" placeholder="이메일을 입력해주세요">
+                    <input id="email" name="useremail" type="email" placeholder="이메일을 입력해주세요">
                 </div>
                 <div class="inputarea">
-                    <label>닉네임</label>
+                    <label for="username">닉네임</label>
                     <br>
-                    <input name="useremail" type="email" placeholder="닉네임을 입력해주세요">
+                    <input id="username" name="username" type="email" placeholder="닉네임을 입력해주세요">
                 </div>
                 <div class="inputarea">
-                    <label>비밀번호</label>
+                    <label id="password">비밀번호</label>
                     <br>
                     <div class="input-container">
-                        <input name="userpassword" type="password" placeholder="비밀번호를 입력해주세요">
+                        <input id="password" name="userpassword" type="password" placeholder="비밀번호를 입력해주세요">
                         <img class="password-icon" src="img/input-icon/eye-off.png" alt="passwordicon">
                     </div>
                 </div>
                 <div class="inputarea">
-                    <label>비밀번호 확인</label>
+                    <label for="password-verify">비밀번호 확인</label>
                     <br>
                     <div class="input-container">
-                        <input name="userpassword" type="password" placeholder="비밀번호를 다시 한 번 입력해주세요">
+                        <input id="password-verify" name="userpassword" type="password" placeholder="비밀번호를 다시 한 번 입력해주세요">
                         <img class="password-icon" src="img/input-icon/eye-off.png" alt="passwordicon">
                     </div>
                 </div>

--- a/signup.html
+++ b/signup.html
@@ -4,6 +4,7 @@
         <meta charset="utf-8">
         <title>회원가입</title>
         <link rel="stylesheet" href="loginStyle.css">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
     </head>
     <body>
         <form class="login">

--- a/signup.html
+++ b/signup.html
@@ -1,10 +1,11 @@
 <!DOCTYPE html>
 <html>
-    <head>
+    <head>ㅇ
         <meta charset="utf-8">
         <title>회원가입</title>
         <link rel="stylesheet" href="loginStyle.css">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
     </head>
     <body>
         <form class="login">

--- a/signupStyle.css
+++ b/signupStyle.css
@@ -14,8 +14,7 @@
     --gray-400: #9CA3AF;
     --gray-200: #E5E7EB;
     --gray-100: #F3F4F6;
-    --gray-50:  #F9FAFB;
-    
+    --gray-50: #F9FAFB;
     --blue: #3692FF;
 }
 
@@ -28,7 +27,7 @@ html {
 }
 
 .loginlogo {
-    width: 24.75rem;
+    width: 25rem;
     display: flex;
     align-items: center;
     margin: 0 auto;
@@ -36,28 +35,28 @@ html {
 }
 
 .inputarea {
-    margin-bottom: 1.5rem;
+    margin-bottom: 2rem;
     position: relative;
 }
 
 label {
-    font-size: 1.125rem;
+    font-size: 1.25rem;
     font-weight: 700;
 }
 
 input {
     width: 37rem;
-    height: 1.625rem;
+    height: 2rem;
     padding: 1rem 1.5rem;
     background-color: var(--gray-100);
     border: none;
     outline: none;
-    border-radius: 0.75rem;
+    border-radius: 1rem;
     margin-top: 1rem;
 }
 
 .input-container {
-    position: relative; 
+    position: relative;
     display: flex;
     align-items: center;
 }
@@ -73,25 +72,25 @@ input:focus {
 
 .password-icon {
     position: absolute;
-    width: 1.375rem;
-    right: 1.5625rem;
+    width: 1.5rem;
+    right: 1.5rem;
     top: 50%;
 }
 
 .login-btn {
-    display: flex; 
+    display: flex;
     width: 40rem;
-    height: 3.5rem;
+    height: 4rem;
     background-color: var(--gray-400);
     border-radius: 2.5rem;
     color: var(--gray-100);
-    font-size: 1.25rem;
+    font-size: 1.5rem;
     font-weight: 600;
     align-items: center;
     justify-content: center;
     text-decoration: none;
     border: none;
-    margin-bottom: 1.5rem;
+    margin-bottom: 2rem;
     cursor: pointer;
 }
 
@@ -100,13 +99,13 @@ input:focus {
     justify-content: center;
     align-items: center;
     background-color: #E6F2FF;
-    height: 4.625rem;
+    height: 5rem;
     border-radius: 0.5rem;
-    margin-bottom: 1.5rem;
+    margin-bottom: 2rem;
 }
 
 .simple-login-in {
-    width: 37.125rem;
+    width: 37rem;
     display: flex;
     align-items: center;
     font-size: 1rem;
@@ -120,12 +119,12 @@ input:focus {
 }
 
 .login-icon img {
-    width: 2.625rem;
+    width: 3rem;
 }
 
 .firstuser {
     text-align: center;
-    font-size: 0.875rem;
+    font-size: 1rem;
     font-weight: 500;
     color: var(--gray-800);
 }
@@ -134,40 +133,39 @@ input:focus {
     color: var(--blue);
 }
 
-
-/* Mobile */
 @media (min-width: 375px) and (max-width: 767px) {
-    .login{
-        padding: 0 16px;
+    .login {
+        padding: 0 1rem;
     }
 
-    .loginlogo{
+    .loginlogo {
         width: 65%;
     }
 
-    label{
-        font-size: 14px;
-        margin-bottom: 10px;
+    label {
+        font-size: 1rem;
+        margin-bottom: 1rem;
     }
 
-    input{
+    input {
         width: 100%;
-        max-width: 400px;
+        max-width: 25rem;
         margin: 0 auto;
-        padding: 16px 0;
-        margin-top: 10px;
+        padding: 1rem 0;
+        margin-top: 1rem;
     }
 
-    ::placeholder{
-        padding: 24px;
+    ::placeholder {
+        padding: 1rem;
     }
 
-    .login-btn{
+    .login-btn {
         width: 100%;
+        font-size: 1.3rem;
     }
 
-    .simple-login-in{
+    .simple-login-in {
         width: 100%;
-        padding: 0 23px;
+        padding: 0 2rem;
     }
 }

--- a/signupStyle.css
+++ b/signupStyle.css
@@ -133,3 +133,41 @@ input:focus {
 .firstuser a {
     color: var(--blue);
 }
+
+
+/* Mobile */
+@media (min-width: 375px) and (max-width: 767px) {
+    .login{
+        padding: 0 16px;
+    }
+
+    .loginlogo{
+        width: 65%;
+    }
+
+    label{
+        font-size: 14px;
+        margin-bottom: 10px;
+    }
+
+    input{
+        width: 100%;
+        max-width: 400px;
+        margin: 0 auto;
+        padding: 16px 0;
+        margin-top: 10px;
+    }
+
+    ::placeholder{
+        padding: 24px;
+    }
+
+    .login-btn{
+        width: 100%;
+    }
+
+    .simple-login-in{
+        width: 100%;
+        padding: 0 23px;
+    }
+}

--- a/style.css
+++ b/style.css
@@ -374,6 +374,10 @@ footer {
         margin-top: 24px;
     }
 
+    .search-items-content .item-details{
+        text-align: right;
+    }
+
     .badge{
         font-size: 16px;
         margin-bottom: 8px

--- a/style.css
+++ b/style.css
@@ -31,8 +31,8 @@ header {
     justify-content: space-between;
     align-items: center;
     padding: 0 12.5rem;
-    background-color: var(--gray-50);
     border-bottom: 0.0625rem solid var(--gray-200);
+    background-color: #FFFFFF;
 }
 
 #logo {
@@ -217,6 +217,10 @@ footer {
 
 /* Tablet */
 @media (min-width: 768px) and (max-width: 1199px) {
+    main{
+        background-color: #FCFCFC;
+    }
+
     header {
         padding: 0 24px;
     }
@@ -264,12 +268,17 @@ footer {
         margin-top: 217px;
     }
 
+    .popular-items-section, .search-items-section, .register-items-section {
+        height: auto;
+        margin-bottom: 56px;
+    }
 
     .popular-items-content, .search-items-content, .register-items-content {
         display: grid;
         flex-direction: column;
         align-items: flex-start;
-        padding: 20px;
+        padding: 24px;
+        background-color: #FCFCFC;
     }
 
     .popular-items-content img, .search-items-content img, .register-items-content img{
@@ -278,9 +287,18 @@ footer {
         margin-bottom: 20px;
     }
 
+    .search-items-content img{
+        order: -1;
+    }
+
     .item-details {
         text-align: left;
         width: 100%;
+        margin-top: 24px;
+    }
+
+    .search-items-content .item-details{
+        text-align: right;
     }
 
     .footer-section {

--- a/style.css
+++ b/style.css
@@ -55,7 +55,7 @@ header {
     font-weight: 300;
 }     
 
-.home-top {
+.hero-section {
     width: 100%;
     height: 33.75rem;
     background-color: #CFE5FF;
@@ -64,23 +64,23 @@ header {
     justify-content: center;
 }
 
-.home-top-all {
+.hero-content {
     display: flex;
     align-items: center;
     margin: 0 auto;
 }
 
-.home-top-content {
+.hero-text {
     font-size: 2.5rem;
     font-weight: 700;
     line-height: 3.5rem;
 }
 
-.home-top h1 {
+.hero-section h1 {
     color: var(--gray-700);
 }
 
-.home-top-img {
+.hero-image {
     height: 21.25rem;
     object-fit: cover;
 }
@@ -102,7 +102,7 @@ header {
     line-height: 2rem;
 }
 
-.home-top-button {
+.cta-button {
     display: block;
     text-decoration: none;
     color: var(--gray-50);
@@ -123,14 +123,14 @@ header {
     margin-bottom: 0.75rem;
 }
 
-.home-first, .home-second, .home-third {
+.popular-items-section, .search-items-section, .register-items-section {
     width: 100%;
     height: 45rem;
     display: flex;
     align-items: center;
 }
 
-.home-first-all, .home-second-all, .home-third-all {
+.popular-items-content, .search-items-content, .register-items-content {
     display: flex;
     width: 60.25rem;
     background-color: var(--gray-50);
@@ -139,17 +139,17 @@ header {
     border-radius: 0.75rem;
 }
 
-.home-first-content, .home-second-content, .home-third-content {
+.item-details {
     margin: 0 auto;
 }
 
-.bottom-grayBox {
+.divider {
     width: 100%;
     height: 8.125rem;
     background-color: var(--gray-50);
 }
 
-.home-bottom {
+.trust-section {
     width: 100%;
     height: 33.75rem;
     background-color: #CFE5FF;
@@ -158,7 +158,7 @@ header {
     justify-content: center;
 }
 
-.home-bottom-all {
+.trust-content {
     font-size: 2.5rem;
     font-weight: 700;
     line-height: 3.5rem;
@@ -167,12 +167,12 @@ header {
     margin: 0 auto;
 }
 
-.home-bottom h1 {
+.trust-section h1 {
     color: var(--gray-700);
     margin: 0;
 }
 
-.home-bottom-img {
+.trust-image {
     width: 46.625rem;
 }
 
@@ -182,7 +182,7 @@ footer {
     display: flex;
 }
 
-.footer-all {
+.footer-section {
     width: 70rem;
     display: flex;
     justify-content: space-between;
@@ -190,26 +190,25 @@ footer {
     margin-top: 2rem;
 }
 
-.footer-first {
+.footer-content {
     color: var(--gray-400);
     font-size: 1rem;
     font-weight: 400;
 }
 
-.footer-second a {
+.footer-policy-faq a {
     text-decoration: none;
     color: var(--gray-200);
     font-size: 1rem;
     font-weight: 400; 
 }
 
-.footer-third {
+.footer-sns {
     display: flex;
     width: 7.25rem;
     gap: 0.75rem;
 }
 
-.footer-third img {
+.footer-sns img {
     height: 1.25rem;
 }
-

--- a/style.css
+++ b/style.css
@@ -74,6 +74,7 @@ header {
     font-size: 2.5rem;
     font-weight: 700;
     line-height: 3.5rem;
+    color: var(--gray-700);
 }
 
 .hero-section h1 {
@@ -107,6 +108,7 @@ header {
     text-decoration: none;
     color: var(--gray-50);
     background-color: var(--blue);
+    width: 357px;
     height: 3.5rem;
     text-align: center;
     border-radius: 2.5rem;
@@ -211,4 +213,92 @@ footer {
 
 .footer-sns img {
     height: 1.25rem;
+}
+
+/* PC */
+@media (min-width: 1200px) {
+    
+}
+
+/* Tablet */
+@media (min-width: 768px) and (max-width: 1199px) {
+    header {
+        padding: 0 24px;
+    }
+
+    .hero-section {
+        height: 771px;
+        margin-bottom: 7rem;
+    }
+
+    .hero-content {
+        flex-direction: column;
+    }
+
+    .cta-button{
+        margin: auto;
+        margin-top: 24px;
+    }
+
+    .hero-text {
+        justify-content: center;
+    }
+
+    .hero-image{
+        padding-top: 210px;
+    }
+
+    .onlyPC{
+        display: none;
+    }
+
+    .bottom-grayBox{
+        display: none;
+    }
+
+    .trust-section {
+        height: 927px;
+        background-color: #CFE5FF;
+    }
+
+    .trust-content{
+        flex-direction: column;
+        text-align: center;
+    }
+
+    .trust-image{
+        margin-top: 217px;
+    }
+
+
+    .popular-items-content, .search-items-content, .register-items-content {
+        flex-direction: column;
+        align-items: flex-start;
+        padding: 20px;
+    }
+
+    .popular-items-content img, .search-items-content img, .register-items-content img{
+        width: 100%;
+        height: auto;
+        margin-bottom: 20px;
+    }
+
+    .item-details {
+        text-align: left;
+        width: 100%;
+    }
+
+    .footer-section {
+        width: 100%;
+        margin: 0 auto;
+        margin-top: 2rem;
+        padding: 0 120px;
+    }
+    
+    
+}
+
+/* Mobile */
+@media (min-width: 375px) and (max-width: 767px) {
+    
 }

--- a/style.css
+++ b/style.css
@@ -81,11 +81,6 @@ header {
     color: var(--gray-700);
 }
 
-.hero-image {
-    height: 21.25rem;
-    object-fit: cover;
-}
-
 .sub {
     color: var(--gray-700);
 }
@@ -108,8 +103,7 @@ header {
     text-decoration: none;
     color: var(--gray-50);
     background-color: var(--blue);
-    width: 357px;
-    height: 3.5rem;
+    padding: 16px, 124px, 16px, 124px;
     text-align: center;
     border-radius: 2.5rem;
     font-size: 1.25rem;
@@ -167,6 +161,7 @@ header {
     display: flex;
     align-items: center;
     margin: 0 auto;
+    color: var(--gray-700);
 }
 
 .trust-section h1 {
@@ -228,7 +223,6 @@ footer {
 
     .hero-section {
         height: 771px;
-        margin-bottom: 7rem;
     }
 
     .hero-content {
@@ -272,6 +266,7 @@ footer {
 
 
     .popular-items-content, .search-items-content, .register-items-content {
+        display: grid;
         flex-direction: column;
         align-items: flex-start;
         padding: 20px;
@@ -300,5 +295,126 @@ footer {
 
 /* Mobile */
 @media (min-width: 375px) and (max-width: 767px) {
+
+    header {
+        padding: 0 24px;
+    }
+
+    .hero-section {
+        height: 771px;
+        height: 540px ;
+    }
+
+    .hero-content {
+        flex-direction: column;
+        overflow: hidden;
+    }
+
+    .hero-text{
+        font-size: 2rem;
+        text-align: center;
+        line-height: 45px;
+    }
+
+    .cta-button{
+        margin: auto;
+        margin-top: 24px;
+        font-size: 18px;
+        padding: 9px, 71px, 12px, 9px;
+        margin-top: 17px;
+    }
+
+    .hero-image {
+        width: 120%;
+        margin-top: 130px;
+    }
+
+    .popular-items-section, .search-items-section, .register-items-section {
+        height: auto;
+    }
+
+    .popular-items-content, .search-items-content, .register-items-content {
+        display: grid;
+        flex-direction: column;
+        align-items: flex-start;
+        padding: 20px;
+        background-color: #FCFCFC;
+    }
+
+    .popular-items-content img, .search-items-content img, .register-items-content img{
+        width: 100%;
+        height: auto;
+    }
+
+    .search-items-content img{
+        order: -1;
+    }
+
+    .item-details {
+        text-align: left;
+        width: 100%;
+        margin-top: 24px;
+    }
+
+    .badge{
+        font-size: 16px;
+        margin-bottom: 8px
+    }
+
+    .subtitle{
+        font-size: 24px;
+        line-height: 2rem;
+        margin-bottom: 20px;
+    }
+
+    .subtitle .onlyPC{
+        display: none;
+    }
+
+    .sub-content{
+        font-size: 16px;
+        line-height: 25px;
+    }
+
+    .bottom-grayBox{
+        display: none;
+    }
+
+    .trust-section {
+        height: 540px;
+        background-color: #CFE5FF;
+    }
+
+    .trust-content{
+        flex-direction: column;
+        text-align: center;
+        font-size: 2rem;
+        line-height: 43px;
+    }
+
+    .trust-image{
+        max-width: 100%;
+        margin-top: 130px;
+    }
+
+    .footer-section {
+        height: 10rem;
+        padding: 0 32px;
+    }
+
     
+
+    .footer-policy-faq a {
+        text-decoration: none;
+        color: var(--gray-200);
+        font-size: 1rem;
+        font-weight: 400;
+        gap: 30px;
+    }
+
+    .footer-content{
+        position: absolute;
+        margin-top: 60px;
+    }
+
 }


### PR DESCRIPTION
## 요구사항
Github에 PR(Pull Request)을 만들어서 미션을 제출합니다.
피그마 디자인에 맞게 페이지를 만들어 주세요.
React와 같은 UI 라이브러리를 사용하지 않고 진행합니다.
### 기본
**공통**
- [x] 브라우저에 현재 보이는 화면의 영역(viewport) 너비를 기준으로 분기되는 반응형 디자인을 적용합니다.
PC: 1200px 이상
Tablet: 768px 이상 ~ 1199px 이하
Mobile: 375px 이상 ~ 767px 이하
375px 미만 사이즈의 디자인은 고려하지 않습니다

**랜딩페이지**
- [x] Tablet 사이즈로 작아질 때 “판다마켓” 로고의 왼쪽에 여백 24px, “로그인” 버튼 오른쪽 여백 24px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [x] Mobile 사이즈로 작아질 때 “판다마켓” 로고의 왼쪽에 여백 16px, “로그인” 버튼 오른쪽 여백 16px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [x] 화면 영역이 줄어들면 “Privacy Policy”, “FAQ”, “codeit-2024”이 있는 영역과 SNS 아이콘들이 있는 영역의 간격이 줄어듭니다.

**로그인, 회원가입 페이지 공통**
- [x] Tablet 사이즈에서 내부 디자인은 PC사이즈와 동일합니다.
- [x] Mobile 사이즈에서 좌우 여백 16px 제외하고 내부 요소들이 너비를 모두 차지합니다.
- [x] Mobile 사이즈에서 내부 요소들의 너비는 기기의 너비가 커지는 만큼 커지지만 400px을 넘지 않습니다.

### 심화
 - [x] 페이스북, 카카오톡, 디스코드, 트위터 등 SNS에서 Linkbrary 랜딩 페이지(“/”) 공유 시 좌측 예시와 같은 미리보기를 볼 수 있도록 랜딩 페이지 메타 태그를 설정해 주세요.
 - [x] 미리보기에서 제목은 “판다 마켓”, 설명은 “일상의 모든 물건을 거래해보세요”로 설정합니다.
 주소와 이미지는 자유롭게 설정하세요.

## 사이트 주소
https://paaaaaandamarket.netlify.app/

## 스크린샷
https://torch-resolution-35a.notion.site/108802dbf03580dfbe6bd5af1d6f6262

## 멘토에게

- 메인 css 단위가 통일되지 않았는데 차후 수정하겠습니다!
- 메타태그를 추가했는데 적용이 안 되는 거 같습니다.
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
