### PR TITLE
Basic 한승지 sprint3

### DIFF
--- a/index.css
+++ b/index.css
@@ -197,9 +197,32 @@
   display: flex;
   gap: 12px;
 }
-
-@media (0px < width < 1920px) {
+/* 반응형 디자인 */
+@media (1200px < width < 1920px) {
   .header {
     padding: 8px 200px;
+  } 
+}
+
+@media (768px < width < 1199px) {
+  .header {
+    padding: 8px 24px;
+  } 
+  .information_section > div {
+    flex-direction: column;
+  }
+  .information_section > div:has(.reverse) {
+    flex-direction: column-reverse;
+  }
+}
+@media (375px < width < 767px) {
+  .header {
+    padding: 8px 16px;
+  }
+  .information_section > div {
+    flex-direction: column;
+  }
+  .information_section > div:has(.reverse) {
+    flex-direction: column-reverse;
   } 
 }

--- a/index.html
+++ b/index.html
@@ -3,6 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="og:image" content="./assets/images/panda_logo.png" />
+    <meta name="og:title" content="판다 마켓" />
+    <meta name="og:description" content="일상의 모든 물건을 거래해보세요" />
     <title>판다마켓</title>
     <link
       rel="stylesheet"

--- a/index.html
+++ b/index.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="og:image" content="./assets/images/panda_logo.png" />
-    <meta name="og:title" content="판다 마켓" />
-    <meta name="og:description" content="일상의 모든 물건을 거래해보세요" />
+    <meta property="og:image" content="./assets/images/panda_logo.png" />
+    <meta property="og:title" content="판다 마켓" />
+    <meta property="og:description" content="일상의 모든 물건을 거래해보세요" />
     <title>판다마켓</title>
     <link
       rel="stylesheet"

--- a/pages/login/login.css
+++ b/pages/login/login.css
@@ -121,3 +121,21 @@
   text-decoration: underline;
   color: var(--blue);
 }
+/* 반응형 디자인 */
+@media (375px < width < 767px) {
+  .root_layout {
+    padding: 0px 16px;
+  }
+  .main {
+    max-width: 400px;
+  }
+  .main_logo > img {
+    width: 52px;
+    height: 52px;
+  }
+  .main_logo > a {
+  font-size: 33.17px;
+  font-weight: 700;
+  line-height: 44.78px;
+  }
+}

--- a/pages/signUp/signup.css
+++ b/pages/signUp/signup.css
@@ -122,3 +122,21 @@
   text-decoration: underline;
   color: var( --blue);
 }
+/* 반응형 디자인 */
+@media (375px < width < 767px) {
+  .root_layout {
+    padding: 0px 16px;
+  }
+  .main {
+    max-width: 400px;
+  }
+  .main_logo > img {
+    width: 52px;
+    height: 52px;
+  }
+  .main_logo > a {
+  font-size: 33.17px;
+  font-weight: 700;
+  line-height: 44.78px;
+  }
+}


### PR DESCRIPTION
## 요구사항
- Github에 PR(Pull Request)을 만들어서 미션을 제출합니다.
- 피그마 디자인에 맞게 페이지를 만들어 주세요.
- React와 같은 UI 라이브러리를 사용하지 않고 진행합니다.

### 기본
공통

브라우저에 현재 보이는 화면의 영역(viewport) 너비를 기준으로 분기되는 반응형 디자인을 적용합니다.
PC: 1200px 이상
Tablet: 768px 이상 ~ 1199px 이하
Mobile: 375px 이상 ~ 767px 이하
375px 미만 사이즈의 디자인은 고려하지 않습니다

랜딩 페이지

- [x] Tablet 사이즈로 작아질 때 “판다마켓” 로고의 왼쪽에 여백 24px, “로그인” 버튼 오른쪽 여백 24px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [x] Mobile 사이즈로 작아질 때 “판다마켓” 로고의 왼쪽에 여백 16px, “로그인” 버튼 오른쪽 여백 16px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [ ] 화면 영역이 줄어들면 “Privacy Policy”, “FAQ”, “codeit-2024”이 있는 영역과 SNS 아이콘들이 있는 영역의 간격이 줄어듭니다.

로그인, 회원가입 페이지 공통

- [x] Tablet 사이즈에서 내부 디자인은 PC사이즈와 동일합니다.
- [x] Mobile 사이즈에서 좌우 여백 16px 제외하고 내부 요소들이 너비를 모두 차지합니다.
- [x] Mobile 사이즈에서 내부 요소들의 너비는 기기의 너비가 커지는 만큼 커지지만 400px을 넘지 않습니다.

### 심화

- [x] 페이스북, 카카오톡, 디스코드, 트위터 등 SNS에서 Linkbrary 랜딩 페이지(“/”) 공유 시 좌측 예시와 같은 미리보기를 볼 수 있도록 랜딩 페이지 메타 태그를 설정해 주세요.
- [x] 미리보기에서 제목은 “판다 마켓”, 설명은 “일상의 모든 물건을 거래해보세요”로 설정합니다.
- [x] 주소와 이미지는 자유롭게 설정하세요.

## 주요 변경사항

-

## 스크린샷

![image](https://github.com/user-attachments/assets/e58b36a6-aae2-4513-ae15-d7b8b89ccb49)


## 멘토에게

- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
- 그동안 감사했습니다 ! 즐거운 주말 보내세요 
