### PR TITLE
[장수경] Sprint3

### DIFF
--- a/home.css
+++ b/home.css
@@ -60,7 +60,7 @@ a {
     cursor: pointer;
 }
 
-.items {
+.items_btn {
     margin-top: 32px;
     width: 357px;
     height: 56px;
@@ -185,7 +185,7 @@ footer {
 
 .home_section:nth-child(3) {
     text-align: right;
-  }
+}
 
 .home_div {
     background-color: #FCFCFC;
@@ -197,15 +197,234 @@ footer {
 }
 
 /* 글 정렬 */
-.text01 {
+.text {
     margin: 0 auto;
 }
 
-.text02 {
-    margin: 0 auto;
-    
+/* 반응형 */
+/* PC */
+@media (min-width: 1200px) {
+
 }
 
-.text03 {
-    margin: 0 auto;
+/* Tablet */
+@media (min-width: 768px) and (max-width: 1199px) {
+    .nav {
+        padding: 0 24px;
+    }
+
+    .banner {
+        height: 771px;
+        background-size: 120%;
+    }
+
+    .banner .subtitle {
+        font-size: 40px;
+        line-height: 56px;
+        padding-top: 84px;
+        padding-bottom: 24px;
+    }
+
+    .banner .subtitle .brPc {
+        display: none;
+    }
+
+    .home_top_div {
+        flex-direction: column;
+        text-align: center;
+    }
+
+    .items_btn{
+        margin: auto;
+        margin-top: 24px;
+    }
+
+    .div_top {
+        justify-content: center;
+    }
+
+    .home_img_top {
+        margin-top: 211px;
+        width: 744px;
+        height: 340px;
+    }
+
+    .brPc{
+        display: none;
+    }
+
+    .home_bottom_section {
+        height: 927px;
+        background-color: #CFE5FF;
+    }
+
+    .home_bottom_div {
+        flex-direction: column;
+        text-align: center;
+    }
+
+    .home_img_bottom {
+        margin-top: 217px;
+    }
+
+    .container {
+        height: auto;
+        margin-bottom: 52px;
+    }
+
+    .home_div {
+        display: grid;
+        flex-direction: column;
+        align-items: flex-start;
+        padding: 24px;
+        background-color: #ffffff;
+    }
+
+    .home_img {
+        width: 100%;
+        height: auto;
+        margin-bottom: 20px;
+    }
+
+    .text {
+        text-align: left;
+        width: 100%;
+        margin-top: 24px;
+    }
+
+    .home_section:nth-child(3) {
+        text-align: right;
+    }
+
+    .codeit {
+        flex-basis: auto;
+        order: 0;
+    }
+}
+
+
+/* Mobile */
+@media (min-width: 375px) and (max-width: 767px) {
+    header {
+        padding: 0 24px;
+    }
+
+    .nav {
+        padding: 0 16px;
+    }
+
+    .banner {
+        height: 771px;
+        background-size: 120%;
+    }
+
+    .banner .subtitle {
+        font-size: 40px;
+        line-height: 56px;
+        padding-top: 0;
+        padding-bottom: 32px;
+    }
+
+    .banner .subtitle .brPc {
+        display: inline;
+    }
+
+    .home_top_div {
+        flex-direction: column;
+        text-align: center;
+        overflow: hidden;
+    }
+
+    .div_top {
+        font-size: 32px;
+        line-height: 44.8px;
+        text-align: center;
+        justify-content: center;
+    }
+
+    .items_btn {
+        margin: auto;
+        margin-top: 18px;
+        font-size: 18px;
+        padding: 9px 71px;
+        margin-top: 17px;
+    }
+
+    .home_img_top {
+        width: 120%;
+        height: 120%;
+        margin-top: 130px;
+    }
+
+    .container {
+        height: auto;
+    }
+
+    .home_div {
+        display: grid;
+        flex-direction: column;
+        align-items: flex-start;
+        padding: 20px;
+        background-color: #ffffff;
+    }
+
+    .home_img {
+        width: 100%;
+        height: auto;
+    }
+
+    .text {
+        text-align: left;
+        width: 100%;
+        margin-top: 24px;
+    }
+
+    .home_section:nth-child(3) {
+        text-align: right;
+    }
+
+    .ptitle {
+        font-size: 16px;
+        margin-bottom: 8px;
+    }
+
+    .subtitle {
+        font-size: 24px;
+        line-height: 32px;
+        margin-bottom: 20px;
+    }
+
+    .pcontent {
+        font-size: 16px;
+        line-height: 25px;
+    }
+
+    .banner {
+        height: 540px;
+        background-color: #CFE5FF;
+    }
+
+    .home_bottom_div {
+        flex-direction: column;
+        text-align: center;
+        font-size: 2rem;
+        line-height: 43px;
+    }
+
+    .home_img_bottom {
+        max-width: 100%;
+        margin-top: 130px;
+    }
+
+    .footer_menu a {
+        text-decoration: none;
+        font-size: 16px;
+        font-weight: 400;
+        gap: 30px;
+    }
+
+    .codeit {
+        position: absolute;
+        margin-top: 60px;
+    }
 }

--- a/home.css
+++ b/home.css
@@ -9,7 +9,7 @@ a {
     color: inherit;
 }
 
-h1 {
+.subtitle {
     font-size: 40px;
     font-weight: 700;
     line-height: 56px;
@@ -35,7 +35,7 @@ h1 {
     background-color: #cfe5ff;
     height: 540px;
     display: flex;
-    align-items: center;
+    align-items: flex-end;
     background-repeat: no-repeat;
     background-position: 80% bottom;
     background-size: 55%;
@@ -142,17 +142,7 @@ footer {
     height: 340px;
 }
 
-.home_img_01 {
-    width: 579px;
-    height: 444px;
-}
-
-.home_img_02 {
-    width: 579px;
-    height: 444px;
-}
-
-.home_img_03 {
+.home_img {
     width: 579px;
     height: 444px;
 }
@@ -170,19 +160,13 @@ footer {
     margin-bottom: 0;
 }
 
-.section01 {
-    background-color: #ffffff;
-    width: 100%;
-    height: 720px;
+.home_top_div {
+    display: flex;
+    align-items: center;
+    margin: 0 auto;
 }
 
-.section02 {
-    background-color: #ffffff;
-    width: 100%;
-    height: 720px;
-}
-
-.section03 {
+.container {
     background-color: #ffffff;
     width: 100%;
     height: 720px;
@@ -193,25 +177,17 @@ footer {
     height: 540px;
 }
 
-.div01 {
-    background-color: #FCFCFC;
-    width: 988px;
-    height: 444px;
+.home_bottom_div {
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    margin: 0 auto;
 }
 
-.div02 {
-    background-color: #FCFCFC;
-    width: 988px;
-    height: 444px;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-}
+.home_section:nth-child(3) {
+    text-align: right;
+  }
 
-.div03 {
+.home_div {
     background-color: #FCFCFC;
     width: 988px;
     height: 444px;

--- a/index.html
+++ b/index.html
@@ -2,6 +2,15 @@
 <html>
     <head>
         <meta charset="utf-8">
+
+        <!-- 반응형 -->
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta property="og:title" content="판다마켓" />
+        <meta property="og:url" content="https://panda_market.netlify.app" />
+        <meta property="og:type" content="website" />
+        <meta property="og:description" content="일상의 모든 물건을 거래해보세요. 판다 마켓에서 쉽고 빠르게 거래를 시작하세요.">
+        <meta property="og:image" content="">
+
         <title>판다마켓</title>
         <link
             rel="stylesheet"
@@ -14,15 +23,15 @@
     <body>
         <header class="nav">
             <a href="index.html"><img class="logo" src="logo.svg" alt="판다마켓"></a>
-            <button href="signin.html" class="login">로그인</button>
+            <button onclick="location.href='signin.html'" class="login">로그인</button>
         </header>
         
         <main>
             <section class="home_top_section banner">
                 <div class="home_top_div">
                     <div class="div_top">
-                        <p class="subtitle">일상의 모든 물건을<br>거래해 보세요</p><br>
-                        <a href="items.html" class="itemsbtn"><button class="items">구경하러 가기</button></a>
+                        <p class="subtitle top_sub">일상의 모든 물건을 <br class="brPc">거래해 보세요</p><br>
+                        <button onclick="location.href='items.html'" class="items_btn">구경하러 가기</button>
                     </div>
                     <img class="home_img_top" src="Img_home_top.png" alt="판다">
                 </div>
@@ -31,20 +40,20 @@
             <section class="home_section container">
                 <div class="home_div">
                     <img class="home_img" src="Img_home_01.png" alt="인기 상품">
-                    <div class="text01">
+                    <div class="text">
                         <p class="ptitle">Hot item</p><br>
-                        <p class="subtitle">인기 상품을<br>확인해 보세요</p><br>
-                        <p class="pcontent">가장 HOT한 중고거래 물품을<br>판다 마켓에서 확인해 보세요</p>
+                        <p class="subtitle">인기 상품을 <br class="brPc">확인해 보세요</p><br>
+                        <p class="pcontent">가장 HOT한 중고거래 물품을 <br>판다 마켓에서 확인해 보세요</p>
                     </div>
                 </div>
             </section>
             
             <section class="home_section container">
                 <div class="home_div">
-                    <div class="text02">
+                    <div class="text">
                         <p class="ptitle">Search</p><br>
-                        <p class="subtitle">구매를 원하는<br>상품을 검색하세요</p><br>
-                        <p class="pcontent">구매하고 싶은 물품은 검색해서<br>쉽게 찾아보세요</p>
+                        <p class="subtitle">구매를 원하는 <br class="brPc">상품을 검색하세요</p><br>
+                        <p class="pcontent">구매하고 싶은 물품은 검색해서 <br>쉽게 찾아보세요</p>
                     </div>
                     <img class="home_img" src="Img_home_02.png" alt="상품 검색">
                 </div>
@@ -53,7 +62,7 @@
             <section class="home_section container">
                 <div class="home_div">
                     <img class="home_img" src="Img_home_03.png" alt="상품 등록">
-                    <div class="text03">
+                    <div class="text">
                         <p class="ptitle">Register</p><br>
                         <p class="subtitle">판매를 원하는<br>상품을 등록하세요</p><br>
                         <p class="pcontent">어떤 물건이든 판매하고 싶은 상품을<br>쉽게 등록하세요</p>
@@ -66,7 +75,7 @@
             <section class="home_bottom_section banner">
                 <div class="home_bottom_div">
                     <div class="bottom_div">
-                        <p class="subtitle">믿을 수 있는<br>판다마켓 중고 거래</p>
+                        <p class="subtitle">믿을 수 있는 <br class="brPc">판다마켓 중고 거래</p>
                     </div>
                     <img class="home_img_bottom" src="Img_home_bottom.png" alt="판다">
                 </div>
@@ -76,7 +85,7 @@
 
 
         <footer>
-            <div id="codeit">@codeit - 2024</div>
+            <div class="codeit">@codeit - 2024</div>
             <div class="footer_menu">
                 <a href="privacy.html">Pricacy Policy</a>
                 <a href="faq.html">FAQ</a>

--- a/index.html
+++ b/index.html
@@ -13,47 +13,49 @@
         <link rel="stylesheet" href="home.css">
     <body>
         <header class="nav">
-            <a href="index.html"><img class="logo" src="logo.svg" alt="판다마켓 로고"></a>
-            <a href="signin.html" id="loginbtn"><button class="login">로그인</button></a>
+            <a href="index.html"><img class="logo" src="logo.svg" alt="판다마켓"></a>
+            <button href="signin.html" class="login">로그인</button>
         </header>
         
         <main>
-            <section id="home-top-section" class="banner">
-                <div class="div_top">
-                    <h1>일상의 모든 물건을<br>거래해 보세요</h1><br>
-                    <a href="items.html" id="itemsbtn"><button class="items">구경하러 가기</button></a>
+            <section class="home_top_section banner">
+                <div class="home_top_div">
+                    <div class="div_top">
+                        <p class="subtitle">일상의 모든 물건을<br>거래해 보세요</p><br>
+                        <a href="items.html" class="itemsbtn"><button class="items">구경하러 가기</button></a>
+                    </div>
+                    <img class="home_img_top" src="Img_home_top.png" alt="판다">
                 </div>
-                <img class="home_img_top" src="Img_home_top.png" alt="Home Top">
             </section>
             
-            <section class="home_section" class="section01">
-                <div class="div01">
-                    <img class="home_img_01" src="Img_home_01.png" alt="인기 상품">
+            <section class="home_section container">
+                <div class="home_div">
+                    <img class="home_img" src="Img_home_01.png" alt="인기 상품">
                     <div class="text01">
                         <p class="ptitle">Hot item</p><br>
-                        <h1>인기 상품을<br>확인해 보세요</h1><br>
+                        <p class="subtitle">인기 상품을<br>확인해 보세요</p><br>
                         <p class="pcontent">가장 HOT한 중고거래 물품을<br>판다 마켓에서 확인해 보세요</p>
                     </div>
                 </div>
             </section>
             
-            <section class="home_section" class="section02">
-                <div class="div02">
+            <section class="home_section container">
+                <div class="home_div">
                     <div class="text02">
                         <p class="ptitle">Search</p><br>
-                        <h1>구매를 원하는<br>상품을 검색하세요</h1><br>
+                        <p class="subtitle">구매를 원하는<br>상품을 검색하세요</p><br>
                         <p class="pcontent">구매하고 싶은 물품은 검색해서<br>쉽게 찾아보세요</p>
                     </div>
-                    <img class="home_img_02" src="Img_home_02.png" alt="상품 검색">
+                    <img class="home_img" src="Img_home_02.png" alt="상품 검색">
                 </div>
             </section>
 
-            <section class="home_section" class="section03">
-                <div class="div03">
-                    <img class="home_img_03" src="Img_home_03.png" alt="상품 등록">
+            <section class="home_section container">
+                <div class="home_div">
+                    <img class="home_img" src="Img_home_03.png" alt="상품 등록">
                     <div class="text03">
                         <p class="ptitle">Register</p><br>
-                        <h1>판매를 원하는<br>상품을 등록하세요</h1><br>
+                        <p class="subtitle">판매를 원하는<br>상품을 등록하세요</p><br>
                         <p class="pcontent">어떤 물건이든 판매하고 싶은 상품을<br>쉽게 등록하세요</p>
                     </div>
                 </div>
@@ -61,11 +63,13 @@
                 
             
             
-            <section id="home_bottom_section" class="banner">
-                <div class="bottom_div">
-                    <h2>믿을 수 있는<br>판다마켓 중고 거래</h2>
+            <section class="home_bottom_section banner">
+                <div class="home_bottom_div">
+                    <div class="bottom_div">
+                        <p class="subtitle">믿을 수 있는<br>판다마켓 중고 거래</p>
+                    </div>
+                    <img class="home_img_bottom" src="Img_home_bottom.png" alt="판다">
                 </div>
-                <img class="home_img_bottom" src="Img_home_bottom.png" alt="Home bottom">
             </section>
         </main>
         

--- a/sign.css
+++ b/sign.css
@@ -71,7 +71,7 @@ button {
     border-radius: 40px;
     font-weight: 600;
     font-size: 20px;
-    line-height: 24px;
+    line-height: 32px;
     text-align: center;
     color: #FFFFFF;
     cursor: pointer;
@@ -116,4 +116,64 @@ button {
     color: #3692FF;
     text-decoration: underline;
     text-underline-offset: 2px;
+}
+
+/* 반응형 */
+/* PC */
+@media (min-width: 1200px) {
+
+}
+
+/* Tablet */
+@media (min-width: 768px) and (max-width: 1199px) {
+
+}
+
+/* Mobile */
+@media (min-width: 375px) and (max-width: 767px) {
+    .sign_div {
+        width: 100%;
+        max-width: 343px;
+    }
+
+    .signinup {
+        padding: 16px;
+    }
+
+    .logo_img {
+        width: 198px;
+        height: 66px;
+    }
+    
+    .logo_home {
+        margin-bottom: 24px;
+    }
+
+    label {
+        font-size: 14px;
+        line-height: 24px;
+        margin-bottom: 8px;
+    }
+
+    .input {
+        width: 100%;
+        max-width: 343px;
+        height: 56px;
+        margin: 0 auto;
+        padding: 16px 24px;
+        margin-top: 8px;
+    }
+
+    .button {
+        width: 100%;
+        max-width: 343px;
+        height: 56px;
+        font-size: 20px;
+    }
+
+    .social_login_div {
+        width: 100%;
+        max-width: 343px;
+        padding: 16px 16px;
+    }
 }

--- a/sign.css
+++ b/sign.css
@@ -9,7 +9,6 @@
 }
 
 .logo_home {
-    display: block;
     text-align: center;
     margin-top: 60px;
     margin-bottom: 40px;
@@ -29,7 +28,7 @@ label {
     line-height: 26px;
 }
 
-input {
+.input {
     padding: 16px 24px;
     background-color: #F3F4F6;
     border: none;
@@ -40,14 +39,14 @@ input {
     width: 100%;
 }
 
-input::placeholder {
+.input::placeholder {
     color: #9CA3AF;
     font-size: 16px;
     line-height: 26px;
     font-weight: 400;
 }
 
-input:focus {
+.input:focus {
     outline-color: var(#3692FF);
 }
 

--- a/signin.html
+++ b/signin.html
@@ -23,6 +23,7 @@
                 <div class="input_item">
                     <label for="email">이메일</label>
                     <input
+                        class="input"
                         id="email"
                         name="email"
                         type="email"
@@ -32,6 +33,7 @@
                     <label for="password">비밀번호</label>
                     <div class="input_div">
                         <input
+                        class="input"
                         id="password"
                         name="password"
                         type="password"
@@ -40,7 +42,7 @@
                     </div>                
                 </div>
     
-                <a href="login.html"><button type="submit" class="button">로그인</button></a>
+                <button href="login.html" class="button">로그인</button>
             </form>
     
             <div class="social_login_div">

--- a/signin.html
+++ b/signin.html
@@ -2,6 +2,10 @@
 <html>
     <head>
         <meta charset="UTF-8">
+
+        <!-- 반응형 -->
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
         <title>판다마켓 - 로그인</title>
         <link
             rel="stylesheet"
@@ -19,7 +23,7 @@
                 <a href="index.html"><img src="logo.svg" alt="판다마켓 홈" class="logo_img"></a>
             </div>
     
-            <form>
+            <form class="signinup">
                 <div class="input_item">
                     <label for="email">이메일</label>
                     <input

--- a/signup.html
+++ b/signup.html
@@ -23,6 +23,7 @@
                 <div class="input_item">
                     <label for="email">이메일</label>
                     <input
+                        class="input"
                         id="email"
                         name="email"
                         type="email"
@@ -31,15 +32,17 @@
                 <div class="input_item">
                     <label for="nickname">닉네임</label>
                     <input
+                        class="input"
                         id="nickname"
-                        name="nickname"
-                        type="nickname"
+                        name="name"
+                        type="name"
                         placeholder="닉네임을 입력해 주세요.">
                 </div>
                 <div class="input_item">
                     <label for="password">비밀번호</label>
                     <div class="input_div">
                         <input
+                        class="input"
                         id="password"
                         name="password"
                         type="password"
@@ -51,6 +54,7 @@
                     <label for="passwordCheck">비밀번호</label>
                     <div class="input_div">
                         <input
+                        class="input"
                         id="passwordCheck"
                         name="passwordCheck"
                         type="password"
@@ -59,14 +63,14 @@
                     </div>
                 </div>
     
-                <a href="login.html"><button type="submit" class="button">회원가입</button></a>
+                <button href="login.html" class="button">회원가입</button>
             </form>
     
             <div class="social_login_div">
                 <h3>간편 로그인하기</h3>
                 <div class="social_login_buttons_div">
-                    <a href="https://www.google.com/" target="_blank"><img src="google.png" alt="구글 로그인" class="icon_img"></a>
-                    <a href="https://www.kakaocorp.com/page/" target="_blank"><img src="kakao.png" alt="카카오톡 로그인" class="icon_img"></a>
+                    <a href="https://www.google.com/" target="_blank" rel="noreferrer noopener"><img src="google.png" alt="구글 로그인" class="icon_img"></a>
+                    <a href="https://www.kakaocorp.com/page/" target="_blank" rel="noreferrer noopener"><img src="kakao.png" alt="카카오톡 로그인" class="icon_img"></a>
                 </div>
             </div>
     

--- a/signup.html
+++ b/signup.html
@@ -2,6 +2,10 @@
 <html>
     <head>
         <meta charset="UTF-8">
+
+        <!-- 반응형 -->
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
         <title>판다마켓 - 로그인</title>
         <link
             rel="stylesheet"
@@ -16,7 +20,7 @@
     <body>
         <div class="sign_div">
             <div class="logo_home">
-                <a href="index.html"><img src="logo.svg" alt="판다마켓 홈"></a>
+                <a href="index.html"><img src="logo.svg" alt="판다마켓 홈" class="logo_img"></a>
             </div>
     
             <form>


### PR DESCRIPTION
## 요구사항

### 기본

#### 공통
- [x] 브라우저에 현재 보이는 화면의 영역(viewport) 너비를 기준으로 분기되는 반응형 디자인을 적용합니다.
PC: 1200px 이상
Tablet: 768px 이상 ~ 1199px 이하
Mobile: 375px 이상 ~ 767px 이하
375px 미만 사이즈의 디자인은 고려하지 않습니다

#### 랜딩 페이지
- [x] Tablet 사이즈로 작아질 때 “판다마켓” 로고의 왼쪽에 여백 24px, “로그인” 버튼 오른쪽 여백 24px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [x] Mobile 사이즈로 작아질 때 “판다마켓” 로고의 왼쪽에 여백 16px, “로그인” 버튼 오른쪽 여백 16px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [x] 화면 영역이 줄어들면 “Privacy Policy”, “FAQ”, “codeit-2024”이 있는 영역과 SNS 아이콘들이 있는 영역의 간격이 줄어듭니다.

#### 로그인, 회원가입 페이지 공통
- [x] Tablet 사이즈에서 내부 디자인은 PC사이즈와 동일합니다.
- [x] Mobile 사이즈에서 좌우 여백 16px 제외하고 내부 요소들이 너비를 모두 차지합니다.
- [x] Mobile 사이즈에서 내부 요소들의 너비는 기기의 너비가 커지는 만큼 커지지만 400px을 넘지 않습니다.

### 심화
- [ ] 페이스북, 카카오톡, 디스코드, 트위터 등 SNS에서 Linkbrary 랜딩 페이지(“/”) 공유 시 좌측 예시와 같은 미리보기를 볼 수 있도록 랜딩 페이지 메타 태그를 설정해 주세요.
- [ ] 미리보기에서 제목은 “판다 마켓”, 설명은 “일상의 모든 물건을 거래해보세요”로 설정합니다.
주소와 이미지는 자유롭게 설정하세요.

## 주요 변경사항

## 스크린샷

## 멘토에게
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
