### PR TITLE
[김도훈] sprint4

### DIFF
--- a/Sprint-Mission1/js/login.js
+++ b/Sprint-Mission1/js/login.js
@@ -7,6 +7,9 @@ document.addEventListener("DOMContentLoaded", function () {
   const closeEyesbtn = document.querySelector(".close-eyes");
   const openEyesbtn = document.querySelector(".open-eyes");
 
+  let unEmailValid = false;
+  let unPasswordValid = false;
+
   // 에러 메시지 출력 함수
   function showError(inputElement, errorElement, errorMessage) {
     errorElement.textContent = errorMessage;
@@ -22,32 +25,37 @@ document.addEventListener("DOMContentLoaded", function () {
   // 이메일 유효성 검사
   function validateEmail() {
     const emailValue = emailInput.value.trim();
-    clearError(emailInput, emailError)
+    clearError(emailInput, emailError);
 
     if (!emailValue) {
-      showError(emailInput, emailError, "이메일을 입력해주세요.")
-      return false;
+      showError(emailInput, emailError, "이메일을 입력해주세요.");
+      unEmailValid = false;
     } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(emailValue)) {
-      showError(emailInput, emailError, "잘못된 이메일 형식입니다.")
-      return false;
+      showError(emailInput, emailError, "잘못된 이메일 형식입니다.");
+      unEmailValid = false;
+    } else {
+      unEmailValid = true;
     }
-    return true;
+    toggleLoginButton();
   }
 
   // 비밀번호 유효성 검사
   function validatePassword() {
     const passwordValue = passwordInput.value.trim();
-    clearError(passwordInput, passwordError)
+    clearError(passwordInput, passwordError);
 
     if (!passwordValue) {
-      showError(passwordInput, passwordError, "비밀번호를 입력해주세요.")
-      return false;
+      showError(passwordInput, passwordError, "비밀번호를 입력해주세요.");
+      unPasswordValid = false;
     } else if (passwordValue.length < 8) {
-      showError(passwordInput, passwordError, "비밀번호를 8자 이상 입력해주세요.")
-      return false;
+      showError(passwordInput, passwordError, "비밀번호를 8자 이상 입력해주세요.");
+      unPasswordValid = false;
+    } else {
+      unPasswordValid = true;
     }
-    return true;
+    toggleLoginButton();
   }
+
   // 비밀번호 숨김 상태 확인 함수
   function togglePasswordVisibility(passwordType, passwordVisibleButton, passwordInvisibleButton) {
     const inPasswordType = passwordType.getAttribute('type') === 'password';
@@ -59,36 +67,28 @@ document.addEventListener("DOMContentLoaded", function () {
   closeEyesbtn.addEventListener('click', () => togglePasswordVisibility(passwordInput, closeEyesbtn, openEyesbtn));
   openEyesbtn.addEventListener('click', () => togglePasswordVisibility(passwordInput, closeEyesbtn, openEyesbtn));
 
-
   // 로그인 버튼 활성화/비활성화
   function toggleLoginButton() {
-    if (validateEmail() && validatePassword()) {
-      loginButton.classList.remove("disabled");
+    if (unEmailValid && unPasswordValid) {
       loginButton.disabled = false;
     } else {
-      loginButton.classList.add("disabled");
       loginButton.disabled = true;
     }
   }
 
-  // 이메일 focus out 이벤트
-  emailInput.addEventListener("focusout", function () {
-    validateEmail();
-    toggleLoginButton();
-  });
+  // 이메일 및 비밀번호 focus out 이벤트
+  emailInput.addEventListener("focusout", validateEmail);
+  passwordInput.addEventListener("focusout", validatePassword);
 
-  // 비밀번호 focus out 이벤트
-  passwordInput.addEventListener("focusout", function () {
-    validatePassword();
-    toggleLoginButton();
-  });
-
-  
   // 로그인 버튼 클릭 시 폼 제출 및 페이지 이동
   document.getElementById("loginForm").addEventListener("submit", function (event) {
-    event.preventDefault();
-    if (validateEmail() && validatePassword()) {
+    if (unEmailValid && unPasswordValid) {
       window.location.href = "/items.html";
+    } else {
+      event.preventDefault();
+      // 유효하지 않다면 에러 메시지를 다시 확인
+      validateEmail();
+      validatePassword();
     }
   });
 });

--- a/Sprint-Mission1/js/login.js
+++ b/Sprint-Mission1/js/login.js
@@ -7,21 +7,28 @@ document.addEventListener("DOMContentLoaded", function () {
   const closeEyesbtn = document.querySelector(".close-eyes");
   const openEyesbtn = document.querySelector(".open-eyes");
 
+  // 에러 메시지 출력 함수
+  function showError(inputElement, errorElement, errorMessage) {
+    errorElement.textContent = errorMessage;
+    inputElement.classList.add("error");
+  }
 
+  // 에러 메시지 지우기 함수
+  function clearError(inputElement, errorElement) {
+    errorElement.textContent = "";
+    inputElement.classList.remove("error");
+  }
 
   // 이메일 유효성 검사
   function validateEmail() {
     const emailValue = emailInput.value.trim();
-    emailError.textContent = "";
-    emailInput.classList.remove("error");
+    clearError(emailInput, emailError)
 
     if (!emailValue) {
-      emailError.textContent = "이메일을 입력해주세요.";
-      emailInput.classList.add("error");
+      showError(emailInput, emailError, "이메일을 입력해주세요.")
       return false;
     } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(emailValue)) {
-      emailError.textContent = "잘못된 이메일 형식입니다.";
-      emailInput.classList.add("error");
+      showError(emailInput, emailError, "잘못된 이메일 형식입니다.")
       return false;
     }
     return true;
@@ -30,33 +37,23 @@ document.addEventListener("DOMContentLoaded", function () {
   // 비밀번호 유효성 검사
   function validatePassword() {
     const passwordValue = passwordInput.value.trim();
-    passwordError.textContent = "";
-    passwordInput.classList.remove("error");
+    clearError(passwordInput, passwordError)
 
     if (!passwordValue) {
-      passwordError.textContent = "비밀번호를 입력해주세요.";
-      passwordInput.classList.add("error");
+      showError(passwordInput, passwordError, "비밀번호를 입력해주세요.")
       return false;
     } else if (passwordValue.length < 8) {
-      passwordError.textContent = "비밀번호를 8자 이상 입력해주세요.";
-      passwordInput.classList.add("error");
+      showError(passwordInput, passwordError, "비밀번호를 8자 이상 입력해주세요.")
       return false;
     }
     return true;
   }
   // 비밀번호 숨김 상태 확인 함수
-  function togglePasswordVisibility(passwordType, passclosebtn, passopenbtn) {
-    const inPasswordType = passwordType.getAttribute('type') === 'password'; 
-
-    if (inPasswordType) {
-      passwordType.setAttribute('type', 'text'); 
-      passclosebtn.classList.remove('visible');
-      passopenbtn.classList.add('visible');
-    } else {
-      passwordType.setAttribute('type', 'password'); 
-      passclosebtn.classList.add('visible');
-      passopenbtn.classList.remove('visible');
-    }
+  function togglePasswordVisibility(passwordType, passwordVisibleButton, passwordInvisibleButton) {
+    const inPasswordType = passwordType.getAttribute('type') === 'password';
+    passwordType.setAttribute('type', inPasswordType ? 'text' : 'password');
+    passwordVisibleButton.classList.toggle('visible', !inPasswordType);
+    passwordInvisibleButton.classList.toggle('visible', inPasswordType);
   }
 
   closeEyesbtn.addEventListener('click', () => togglePasswordVisibility(passwordInput, closeEyesbtn, openEyesbtn));
@@ -86,6 +83,7 @@ document.addEventListener("DOMContentLoaded", function () {
     toggleLoginButton();
   });
 
+  
   // 로그인 버튼 클릭 시 폼 제출 및 페이지 이동
   document.getElementById("loginForm").addEventListener("submit", function (event) {
     event.preventDefault();

--- a/Sprint-Mission1/js/signup.js
+++ b/Sprint-Mission1/js/signup.js
@@ -11,55 +11,70 @@ document.addEventListener("DOMContentLoaded", function () {
   const chcloseEyesbtn = document.querySelector(".check-p-wrap .close-eyes");
   const chopenEyesbtn = document.querySelector(".check-p-wrap .open-eyes");
 
+  let unEmailValid = false;
+  let unPasswordValid = false;
+  let unchPasswordValid = false;
+
+  // 에러 메시지 출력 함수
+  function showError(inputElement, errorElement, errorMessage) {
+    errorElement.textContent = errorMessage;
+    inputElement.classList.add("error");
+  }
+
+  // 에러 메시지 지우기 함수
+  function clearError(inputElement, errorElement) {
+    errorElement.textContent = "";
+    inputElement.classList.remove("error");
+  }
 
   // 이메일 유효성 검사
   function validateEmail() {
     const emailValue = emailInput.value.trim();
-    emailError.textContent = "";
-    emailInput.classList.remove("error");
+    clearError(emailInput, emailError)
 
     if (!emailValue) {
-      emailError.textContent = "이메일을 입력해주세요.";
-      emailInput.classList.add("error");
-      return false;
+      showError(emailInput, emailError, "이메일을 입력해주세요.")
+      unEmailValid = false;
     } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(emailValue)) {
-      emailError.textContent = "잘못된 이메일 형식입니다.";
-      emailInput.classList.add("error");
-      return false;
+      showError(emailInput, emailError, "잘못된 이메일 형식입니다.")
+      unEmailValid = false;
+      unEmailValid = false;
+    } else {
+      unEmailValid = true;
     }
-    return true;
+    toggleSignupButton()
   }
 
   // 비밀번호 유효성 검사
   function validatePassword() {
     const passwordValue = passwordInput.value.trim();
-    passwordError.textContent = "";
-    passwordInput.classList.remove("error");
+    clearError(passwordInput, passwordError)
 
     if (!passwordValue) {
-      passwordError.textContent = "비밀번호를 입력해주세요.";
-      passwordInput.classList.add("error");
-      return false;
+      showError(passwordInput, passwordError, "비밀번호를 입력해주세요.")
+      unPasswordValid = false;
     } else if (passwordValue.length < 8) {
-      passwordError.textContent = "비밀번호를 8자 이상 입력해주세요.";
-      passwordInput.classList.add("error");
-      return false;
+      showError(passwordInput, passwordError, "비밀번호를 8자 이상 입력해주세요.")
+      unPasswordValid = false;
+    } else {
+      unPasswordValid = true;
     }
-    return true;
+    toggleSignupButton()
+
   }
   // 비밀번호 확인 유효성 검사
   function confirmPassword() {
     const passwordValue = passwordInput.value.trim();
     const chpasswordValue = chpasswordInput.value.trim();
-    chpasswordError.textContent = "";
-    chpasswordInput.classList.remove("error");
+    clearError(chpasswordInput, chpasswordError)
 
     if (passwordValue !== chpasswordValue) {
-      chpasswordError.textContent = "비밀번호가 일치하지 않습니다";
-      chpasswordInput.classList.add("error");
-      return false;
+      showError(chpasswordInput, chpasswordError, "비밀번호가 일치하지 않습니다.")
+      unchPasswordValid = false;
+    } else {
+      unchPasswordValid = true;
     }
-    return true;
+    toggleSignupButton()
 
   }
   // 비밀번호 숨김 상태 확인 함수
@@ -87,37 +102,29 @@ document.addEventListener("DOMContentLoaded", function () {
 
   // 회원가입 버튼 활성화/비활성화
   function toggleSignupButton() {
-    if (validateEmail() && validatePassword() && confirmPassword()) {
-      signButton.classList.remove("disabled");
+    if (unEmailValid && unPasswordValid && unchPasswordValid) {
       signButton.disabled = false;
     } else {
-      signButton.classList.add("disabled");
       signButton.disabled = true;
     }
   }
 
-  // 이메일 focus out 이벤트
-  emailInput.addEventListener("focusout", function () {
-    validateEmail();
-    toggleSignupButton();
-  });
+  
+  // 이메일 및 비밀번호 focus out 이벤트
+  emailInput.addEventListener("focusout", validateEmail);
+  passwordInput.addEventListener("focusout", validatePassword);
+  chpasswordInput.addEventListener("focusout", confirmPassword);
 
-  // 비밀번호 focus out 이벤트
-  passwordInput.addEventListener("focusout", function () {
-    validatePassword();
-    toggleSignupButton();
-  });
-  // 비밀번호 확인 focus out 이벤트
-  chpasswordInput.addEventListener("focusout", function () {
-    confirmPassword();
-    toggleSignupButton();
-  });
 
   // 회원가입 버튼 클릭 시 폼 제출 및 페이지 이동
   document.getElementById("signForm").addEventListener("submit", function (event) {
-    event.preventDefault();
-    if (validateEmail() && validatePassword() && confirmPassword()) {
-      window.location.href = "/login.html";
+    if (unEmailValid && unPasswordValid && unchPasswordValid) {
+      window.location.href = "/login.html"; 
+    } else {
+      event.preventDefault();
+      validateEmail();
+      validatePassword();
+      confirmPassword();
     }
   });
 });

--- a/Sprint-Mission1/login.html
+++ b/Sprint-Mission1/login.html
@@ -19,7 +19,7 @@
                     <div class="logo-txt"><img src="./images/logo/logo_txt.png" alt="로고텍스트"></div>
                 </a>
             </div>
-            <form id="loginForm" action="" name="panda-login">
+            <form id="loginForm" action="/items.html" name="panda-login">
                 <div class="form-wrap">
                     <div class="p-email-wrap">
                         <label for="pandaEmail">이메일</label>

--- a/Sprint-Mission1/signup.html
+++ b/Sprint-Mission1/signup.html
@@ -20,7 +20,7 @@
                     <div class="logo-txt"><img src="./images/logo/logo_txt.png" alt="로고텍스트"></div>
                 </a>
             </div>
-            <form id="signForm" action="" name="signup">
+            <form id="signForm" action="login.html" name="signup">
                 <div class="signup-wrap">
                     <div class="signup-email">
                         <label for="signupEmail">이메일</label>


### PR DESCRIPTION
### 기본

로그인

이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지를 보입니다.
이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 경우 input에 빨강색 테두리와 아래에 “잘못된 이메일 형식입니다” 빨강색 에러 메세지를 보입니다.
비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지를 보입니다
비밀번호 input에서 focus out 할 때, 값이 8자 미만일 경우 아래에 “비밀번호를 8자 이상 입력해주세요.” 에러 메세지를 보입니다.
input 에 빈 값이 있거나 에러 메세지가 있으면 ‘로그인’ 버튼은 비활성화 됩니다.
input 에 유효한 값을 입력하면 ‘로그인' 버튼이 활성화 됩니다.
활성화된 ‘로그인’ 버튼을 누르면 “/items” 로 이동합니다

회원가입

이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지를 보입니다.
이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 경우 input에 빨강색 테두리와 아래에 “잘못된 이메일 형식입니다” 빨강색 에러 메세지를 보입니다.
닉네임 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “닉네임을 입력해주세요.” 빨강색 에러 메세지를 보입니다.
비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지를 보입니다
비밀번호 input에서 focus out 할 때, 값이 8자 미만일 경우 아래에 “비밀번호를 8자 이상 입력해주세요.” 에러 메세지를 보입니다.
비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input 아래에 “비밀번호가 일치하지 않습니다..” 에러 메세지를 보입니다.
input 에 빈 값이 있거나 에러 메세지가 있으면 ‘회원가입’ 버튼은 비활성화 됩니다.
input 에 유효한 값을 입력하면 ‘회원가입' 버튼이 활성화 됩니다.
활성화된 ‘회원가입’ 버튼을 누르면 “/signup” 로 이동합니다

### 심화

눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 합니다.
비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이도록 합니다.

## 주요 변경사항

- sprin3에서 코드리뷰를 참고하여 js파일 전반적으로 수정


## 멘토에게

- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.

## 링크

https://idyllic-halva-3fd990.netlify.app/
https://idyllic-halva-3fd990.netlify.app/login
https://idyllic-halva-3fd990.netlify.app/signup
